### PR TITLE
Add debug logging and log rpki-client output to it

### DIFF
--- a/kartograf/context.py
+++ b/kartograf/context.py
@@ -83,3 +83,5 @@ class Context:
         self.final_result_file = f"{self.out_dir}final_result.txt"
 
         self.max_encode = self.args.max_encode
+
+        self.debug_log = f"{self.out_dir}debug.log"

--- a/kartograf/context.py
+++ b/kartograf/context.py
@@ -84,4 +84,7 @@ class Context:
 
         self.max_encode = self.args.max_encode
 
-        self.debug_log = f"{self.out_dir}debug.log"
+        if self.args.debug:
+            self.debug_log = f"{self.out_dir}debug.log"
+        else:
+            self.debug_log = ""

--- a/run
+++ b/run
@@ -21,6 +21,11 @@ if __name__ == "__main__":
 
     parser_map = subparsers.add_parser("map")
 
+    # Write extended logging information to a debug.log file
+    # TODO: This is always enabled for now but this should be changed when the
+    # tool is more stable
+    parser_map.add_argument("-d", "--debug", action="store_true", default=True)
+
     # Delete artifacts from building the requested map
     parser_map.add_argument("-c", "--cleanup", action="store_true", default=False)
 


### PR DESCRIPTION
We sometimes see issues with `rpki-client` which lead to mismatches in our results. Logging the output from `rpki-client` to a debug.log file should make it easier for us to debug these issues and get help from upstream.