### PR TITLE
nix: Fix links after move to asmap org

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,13 +49,13 @@
       "locked": {
         "lastModified": 1724097265,
         "narHash": "sha256-nVQLVgCKpEfCyFDyQT8TVLBBkY12MVtnJyT9E5qCWPc=",
-        "owner": "fjahr",
+        "owner": "asmap",
         "repo": "rpki-client-nix",
         "rev": "cf9c7238ee751a7924e63ecde1ed2eb7595c9146",
         "type": "github"
       },
       "original": {
-        "owner": "fjahr",
+        "owner": "asmap",
         "repo": "rpki-client-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -86,7 +86,7 @@
           meta = with pkgs.lib; {
             description = "Kartograf: IP to ASN mapping for everyone";
             license = licenses.mit;
-            homepage = "https://github.com/fjahr/kartograf";
+            homepage = "https://github.com/asmap/kartograf";
           };
         };
         default = self.packages.${system}.kartograf;

--- a/nix.md
+++ b/nix.md
@@ -14,6 +14,6 @@ The status quo is to hope every package manager (Brew, Pacman, Yum, APT etc) is:
 
 But this is almost never the case. So using Nix gives you a more consistent and reliable experience when running this project.
 
-Specifically, the `rpki-client` version is set to our own nix-ified [rpki-client](https://github.com/fjahr/rpki-client-nix) repo. We pin the nixpkgs version so that we know that every user will be getting the same version of Python and its deps. If you want to run an older version as we roll forward, you can just check out the appropriate git commit and `nix develop` from there.
+Specifically, the `rpki-client` version is set to our own nix-ified [rpki-client](https://github.com/asmap/rpki-client-nix) repo. We pin the nixpkgs version so that we know that every user will be getting the same version of Python and its deps. If you want to run an older version as we roll forward, you can just check out the appropriate git commit and `nix develop` from there.
 
 If you have any questions or difficulty getting started, feel free to open an issue!


### PR DESCRIPTION
While the redirects work there is no guarantee they will work forever so we should fix the links.