### PR TITLE
add diff command

### DIFF
--- a/kartograf/diff.py
+++ b/kartograf/diff.py
@@ -1,0 +1,48 @@
+def diff(f1, f2, out_file):
+    '''
+    Compare two ASMap files, and write out changes to an out_file.
+    Prints the size of each type of change (assigned, reassigned, or unassigned).
+    '''
+    f1_dict = dict()
+    with open(f1, "r") as f:
+        for line in f:
+            pfx, asn = line.split()
+            f1_dict[pfx] = asn
+
+    f2_dict = dict()
+    with open(f2, "r") as f:
+        for line in f:
+            pfx, asn = line.split()
+            f2_dict[pfx] = asn
+
+    k1 = f1_dict.keys()
+    k2 = f2_dict.keys()
+
+    left = set(k1) - set(k2)
+    right = set(k2) - set(k1)
+    overlap = set(k1) & set(k2)
+
+    changes = []
+    for network in overlap:
+        asn1 = f1_dict[network]
+        asn2 = f2_dict[network]
+        if asn1 != asn2:
+            changes.append(f"{network} reassigned from {asn1} to {asn2}\n")
+
+    removed = []
+    for network in left:
+        removed.append(f"{network} unassigned from {f1_dict[network]} \n")
+
+    added = []
+    for network in right:
+        added.append(f"{network} assigned to {f2_dict[network]}\n")
+
+    with open(out_file, "w") as f:
+        f.writelines(changes + removed + added)
+        f.close()
+
+    print(f"Wrote to {out_file}\n")
+    print(f"Changes: {len(changes)}")
+    print(f"Removed: {len(removed)}")
+    print(f"Added:   {len(added)}")
+

--- a/kartograf/kartograf.py
+++ b/kartograf/kartograf.py
@@ -8,6 +8,7 @@ from kartograf.context import Context
 from kartograf.coverage import coverage
 from kartograf.collectors.routeviews import extract_routeviews_pfx2as, fetch_routeviews_pfx2as
 from kartograf.collectors.parse import parse_routeviews_pfx2as
+from kartograf.diff import diff
 from kartograf.irr.fetch import extract_irr, fetch_irr
 from kartograf.irr.parse import parse_irr
 from kartograf.merge import merge_irr, merge_pfx2as, general_merge
@@ -111,3 +112,7 @@ class Kartograf:
     @staticmethod
     def merge(args):
         general_merge(args.base, args.extra, None, args.output)
+
+    @staticmethod
+    def diff(args):
+        diff(args.base, args.extra, args.output)

--- a/run
+++ b/run
@@ -86,15 +86,22 @@ if __name__ == "__main__":
         action="version",
         version="%(prog)s (version {version})".format(version=kartograf.__version__))
 
+    parser_diff = subparsers.add_parser("diff")
+
+    parser_diff.add_argument("-b", "--base")
+    parser_diff.add_argument("-e", "--extra")
+    parser_diff.add_argument("-o", "--output", default=f'{os.getcwd()}/out/diff.txt')
+
     args = parser.parse_args()
 
-    if args.reproduce and not args.epoch:
-        parser.error('--reproduce is required when --epoch is set.')
-    elif not args.epoch and args.reproduce:
-        parser.error('--epoch is required when --reproduce is set.')
+    if args.command == 'run':
+        if args.reproduce and not args.epoch:
+            parser.error('--reproduce is required when --epoch is set.')
+        elif not args.epoch and args.reproduce:
+            parser.error('--epoch is required when --reproduce is set.')
 
-    if args.wait and args.reproduce:
-        parser.error('--reproduce is not compatible with --wait.')
+        if args.wait and args.reproduce:
+            parser.error('--reproduce is not compatible with --wait.')
 
     if args.command == "map":
         Kartograf.map(args)
@@ -102,6 +109,8 @@ if __name__ == "__main__":
         Kartograf.cov(args)
     elif args.command == "merge":
         Kartograf.merge(args)
+    elif args.command == "diff":
+        Kartograf.diff(args)
     else:
         parser.print_help()
         sys.exit("Please provide a command.")


### PR DESCRIPTION
takes two ASmaps and compares them (new, removed, and changes/transfers). It prints the counts of each, and writes the full set to an output file.

This is similar to the [asmap.py](https://github.com/bitcoin/bitcoin/blob/master/contrib/asmap/asmap.py) diff command, but this operates on text files within the kartograf context instead of a compressed file in Core.

I've been running adhoc scripts to do this frequently. It's needed to start comparing ASmaps continuously and analyzing the churn of networks, and it's a reasonable addition for users of Kartograf in general imo. 