### PR TITLE
initial CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: Kartograf CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@v3
+    - name: Verify Flake Outputs
+      run: |
+        nix flake check
+        nix build .#devShells.x86_64-linux.default
+        nix build .#default
+

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
       #   in the current directory.
       # * A default/kartograf package
       # * A NixOS module
-      devShell = pkgs.mkShell {
+      devShells.default = pkgs.mkShell {
         packages = kartografDeps;
       };
       packages = {


### PR DESCRIPTION
Checks that the flake can be evaluated, and checks that the dev shell and package can be built.
Runs on PRs and pushes to main. 

Also updates the devShell output, which was defined in the old format.