### PR TITLE
Cleanups from #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Kartograf expects files input files to be in the following formatting and also p
 2001:067c:0750:0000:0000:0000:0010:0001
 ```
 
+## Testing
+
+Tests are located under `tests`, and can be run with `pytest`. Run `pytest tests` or specify a specific test with `pytest tests/TEST_NAME.py`.
+
 ## Acknowledgements
 
 [Job Snijders](https://twitter.com/JobSnijders)

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
         ps.beautifulsoup4
         ps.pandas
         ps.pylint
+	ps.pytest
         ps.requests
         ps.tqdm
       ]);

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -44,14 +44,11 @@ class BaseNetworkIndex:
                 return 1
         return 0
 
-    def included(self, row, result_array):
+    def contains_row(self, row):
         root_net = row.PFXS_LEADING
         if root_net in self._keys:
-            result = self.check_inclusion(row, root_net)
-            result_array.append(result)
-        else:
-            result_array.append(0)
-        return result_array
+            return self.check_inclusion(row, root_net)
+        return 0
 
 
 @timed
@@ -133,11 +130,12 @@ def general_merge(
 
     print("Merging extra prefixes that were not included in the base file:\n")
 
-    included = []
+    extra_included = []
     for row in df_extra.itertuples(index=False):
-        base.included(row, included)
+        result = base.contains_row(row)
+        extra_included.append(result)
 
-    df_extra["INCLUDED"] = included
+    df_extra["INCLUDED"] = extra_included
     df_filtered = df_extra[df_extra.INCLUDED == 0]
 
     print("Finished merging extra prefixes.")

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -3,6 +3,8 @@ import shutil
 import pandas as pd
 
 from kartograf.timed import timed
+from kartograf.util import get_root_network
+
 
 class BaseNetworkIndex:
     '''
@@ -30,10 +32,7 @@ class BaseNetworkIndex:
         netw = int(ipn.network_address)
         mask = int(ipn.netmask)
         v = ipn.version
-        if v == 4:
-            root_net = int(str(pfx).split(".", maxsplit=1)[0])
-        else:
-            root_net = int(str(pfx).split(":", maxsplit=1)[0])
+        root_net = get_root_network(pfx)
 
         if (root_net in self._v4_keys) or (root_net in self._v6_keys):
             current = self._dict[v][root_net]
@@ -117,10 +116,7 @@ def extra_file_to_df(extra_file_path):
             extra_nets_int.append(netw_int)
             extra_asns.append(asn.strip())
             extra_pfxs.append(pfx)
-            if ipn.version == 4:
-                root_net = int(pfx.split(".", maxsplit=1)[0])
-            else:
-                root_net = str(pfx).split(":", maxsplit=1)[0]
+            root_net = get_root_network(pfx)
             extra_pfxs_leading.append(root_net)
 
     df_extra = pd.DataFrame({

--- a/kartograf/util.py
+++ b/kartograf/util.py
@@ -138,11 +138,16 @@ def format_pfx(pfx):
     """
     try:
         if "/" in pfx:
+            pattern = r"^0+"
+            match = re.search(pattern, pfx)
+            if match:
+                pfx = re.sub(pattern, "", pfx)
             formatted_pfx = str(ipaddress.ip_network(pfx))
             return f"{formatted_pfx}"
         return str(ipaddress.ip_address(pfx))
     except ValueError:
         return pfx
+
 
 def get_root_network(pfx):
     """

--- a/kartograf/util.py
+++ b/kartograf/util.py
@@ -143,3 +143,18 @@ def format_pfx(pfx):
         return str(ipaddress.ip_address(pfx))
     except ValueError:
         return pfx
+
+def get_root_network(pfx):
+    """
+    Extract the top-level network from an IPv4 or IPv6 address.
+    Returns the value as an integer.
+    """
+    network = format_pfx(pfx)
+    v = ipaddress.ip_network(network).version
+    if v == 4:
+        return int(network.split(".", maxsplit=1)[0])
+
+    root_net = network.split(":", maxsplit=1)[0]
+    if root_net:
+        return int(root_net, 16)
+    return 0

--- a/tests/merge_base_class_test.py
+++ b/tests/merge_base_class_test.py
@@ -1,6 +1,7 @@
 import ipaddress
 import pandas as pd
 from kartograf.merge import BaseNetworkIndex
+from kartograf.util import get_root_network
 
 
 def _df_from_network(network, asn=123):
@@ -8,11 +9,7 @@ def _df_from_network(network, asn=123):
     Create a one-row dataframe that holds the extra file rows in the expected format for contains_row().
     '''
     ipn = ipaddress.ip_network(network)
-    v = ipn.version
-    if v == 4:
-        root_net = int(str(network).split(".", maxsplit=1)[0])
-    else:
-        root_net = int(str(network).split(":", maxsplit=1)[0])
+    root_net = get_root_network(network)
     network_int = int(ipn.network_address)
     df_extra = pd.DataFrame(
         data={"INETS": network_int, "ASNS": asn, "PFXS": network, "PFXS_LEADING": root_net},

--- a/tests/merge_base_class_test.py
+++ b/tests/merge_base_class_test.py
@@ -14,7 +14,6 @@ def _df_from_networks(networks, asn=123):
     for network in networks:
         ipn = ipaddress.ip_network(network)
         root_net = get_root_network(network)
-        print(root_net)
         network_int = int(ipn.network_address)
         df.loc[len(df)] = [network_int, asn, str(ipn), root_net]
     return df

--- a/tests/merge_base_class_test.py
+++ b/tests/merge_base_class_test.py
@@ -4,18 +4,20 @@ from kartograf.merge import BaseNetworkIndex
 from kartograf.util import get_root_network
 
 
-def _df_from_network(network, asn=123):
+def _df_from_networks(networks, asn=123):
     '''
     Create a one-row dataframe that holds the extra file rows in the expected format for contains_row().
     '''
-    ipn = ipaddress.ip_network(network)
-    root_net = get_root_network(network)
-    network_int = int(ipn.network_address)
-    df_extra = pd.DataFrame(
-        data={"INETS": network_int, "ASNS": asn, "PFXS": network, "PFXS_LEADING": root_net},
-        index=[0],
+    df = pd.DataFrame(
+        columns=["INETS", "ASNS", "PFXS", "PFXS_LEADING"],
     )
-    return df_extra
+    for network in networks:
+        ipn = ipaddress.ip_network(network)
+        root_net = get_root_network(network)
+        print(root_net)
+        network_int = int(ipn.network_address)
+        df.loc[len(df)] = [network_int, asn, str(ipn), root_net]
+    return df
 
 
 def test_base_dict_create():
@@ -23,8 +25,9 @@ def test_base_dict_create():
     contains_row returns false when adding a row to an empty base file dict.
     '''
     base = BaseNetworkIndex()
-    network = "10.10.0.0/16"
-    df_extra = _df_from_network(network)
+    ipv4_network = "10.10.0.0/16"
+    ipv6_network = "2c0f:ff90::/32"
+    df_extra = _df_from_networks([ipv4_network, ipv6_network])
     for row in df_extra.itertuples(index=False):
         assert not base.contains_row(row)
 
@@ -34,9 +37,11 @@ def test_base_dict_update():
     contains_row returns true when adding a row already present in the base dict.
     '''
     base = BaseNetworkIndex()
-    network = "10.10.0.0/16"
-    base.update(network)
-    df_extra = _df_from_network(network)
+    ipv4_network = "10.10.0.0/16"
+    ipv6_network = "2c0f:ff90::/32"
+    base.update(ipv4_network)
+    base.update(ipv6_network)
+    df_extra = _df_from_networks([ipv4_network, ipv6_network])
     for row in df_extra.itertuples(index=False):
         assert base.contains_row(row)
 
@@ -49,6 +54,6 @@ def test_check_included_subnet():
     network = "10.10.0.0/16"
     base.update(network)
     subnet = "10.10.0.0/21"
-    df_extra = _df_from_network(subnet)
+    df_extra = _df_from_networks([subnet])
     for row in df_extra.itertuples(index=False):
         assert base.contains_row(row)

--- a/tests/merge_base_class_test.py
+++ b/tests/merge_base_class_test.py
@@ -26,6 +26,7 @@ def test_base_dict_create():
     for row in df_extra.itertuples(index=False):
         assert not base.contains_row(row)
 
+
 def test_base_dict_update():
     '''
     contains_row returns true when adding a row already present in the base dict.
@@ -49,4 +50,3 @@ def test_check_included_subnet():
     df_extra = _df_from_network(subnet)
     for row in df_extra.itertuples(index=False):
         assert base.contains_row(row)
-

--- a/tests/merge_base_class_test.py
+++ b/tests/merge_base_class_test.py
@@ -1,0 +1,52 @@
+import ipaddress
+import pandas as pd
+from kartograf.merge import BaseNetworkIndex
+
+
+def _df_from_network(network, asn=123):
+    '''
+    Create a one-row dataframe that holds the extra file rows in the expected format for contains_row().
+    '''
+    root_net = int(network.split(".", maxsplit=1)[0])
+    network_int = int(ipaddress.ip_network(network).network_address)
+    df_extra = pd.DataFrame(
+        data={"INETS": network_int, "ASNS": asn, "PFXS": network, "PFXS_LEADING": root_net},
+        index=[0],
+    )
+    return df_extra
+
+
+def test_base_dict_create():
+    '''
+    contains_row returns false when adding a row to an empty base file dict.
+    '''
+    base = BaseNetworkIndex()
+    network = "10.10.0.0/16"
+    df_extra = _df_from_network(network)
+    for row in df_extra.itertuples(index=False):
+        assert not base.contains_row(row)
+
+def test_base_dict_update():
+    '''
+    contains_row returns true when adding a row already present in the base dict.
+    '''
+    base = BaseNetworkIndex()
+    network = "10.10.0.0/16"
+    base.update(network)
+    df_extra = _df_from_network(network)
+    for row in df_extra.itertuples(index=False):
+        assert base.contains_row(row)
+
+
+def test_check_included_subnet():
+    '''
+    contains_row returns true when adding a subnet of a row already present in the base dict.
+    '''
+    base = BaseNetworkIndex()
+    network = "10.10.0.0/16"
+    base.update(network)
+    subnet = "10.10.0.0/21"
+    df_extra = _df_from_network(subnet)
+    for row in df_extra.itertuples(index=False):
+        assert base.contains_row(row)
+

--- a/tests/merge_base_class_test.py
+++ b/tests/merge_base_class_test.py
@@ -7,8 +7,13 @@ def _df_from_network(network, asn=123):
     '''
     Create a one-row dataframe that holds the extra file rows in the expected format for contains_row().
     '''
-    root_net = int(network.split(".", maxsplit=1)[0])
-    network_int = int(ipaddress.ip_network(network).network_address)
+    ipn = ipaddress.ip_network(network)
+    v = ipn.version
+    if v == 4:
+        root_net = int(str(network).split(".", maxsplit=1)[0])
+    else:
+        root_net = int(str(network).split(":", maxsplit=1)[0])
+    network_int = int(ipn.network_address)
     df_extra = pd.DataFrame(
         data={"INETS": network_int, "ASNS": asn, "PFXS": network, "PFXS_LEADING": root_net},
         index=[0],

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,57 @@
+from kartograf.util import format_pfx, get_root_network
+
+def test_valid_ipv4_network():
+    pfx = "192.144.11.0/21"
+    assert format_pfx(pfx) == pfx
+
+
+def test_valid_ipv4_addr():
+    pfx = "192.144.11.0"
+    assert format_pfx(pfx) == pfx
+
+
+def test_valid_ipv6_network():
+    pfx = "2001:db8::/64"
+    assert format_pfx(pfx) == pfx
+
+
+def test_valid_ipv6_addr():
+    pfx = "2001:db8::1"
+    assert format_pfx(pfx) == pfx
+
+
+def test_ipv4_prefix_with_leading_zeros():
+    pfx = "010.10.00.00/16"
+    expected_output = "10.10.00.00/16"
+    assert format_pfx(pfx) == expected_output
+
+
+def test_ipv6_prefix_with_leading_zeros():
+    pfx = "001:db8::0/24"
+    expected_output = "1:db8::0/24"
+    assert format_pfx(pfx) == expected_output
+
+
+def test_invalid_ip_network():
+    pfx = "192.1/asdf"
+    assert format_pfx(pfx) == pfx
+
+
+def test_invalid_input():
+    pfx = "no.slash"
+    assert format_pfx(pfx) == pfx
+
+
+def test_get_root_network():
+    ipv4 = "192.144.11.0/24"
+    assert get_root_network(ipv4) == 192
+    ipv6 = "2001:db8::/64"
+    assert get_root_network(ipv6) == int("2001", 16)
+    invalid = "not.a.network"
+    # TODO: use pytest
+    try:
+        get_root_network(invalid)
+    except ValueError:
+        assert True
+    else:
+        assert False


### PR DESCRIPTION
Following up on #30:
- Make dict indexed by IP version
- Subnet indexes are both integers
- refactor some of the logic on inclusion
- rename `included` function to `contains_row`
- pull out the extra file to dataframe logic into its own function
- add a basic test for the `BaseNetworkIndex` class
- address pylint stuff