### PR TITLE
Remove flake-inputs; refactor and split out package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,8 +35,7 @@
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "rpki-cli": "rpki-cli",
-        "utils": "utils_2"
+        "rpki-cli": "rpki-cli"
       }
     },
     "rpki-cli": {
@@ -47,11 +46,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1727388158,
-        "narHash": "sha256-WtNCxHZ7jtpZHEagvWMcyY4pHjFAHk9k/3Z0K3pJka8=",
+        "lastModified": 1727819346,
+        "narHash": "sha256-QX4V5J2Faf2MlUnclQNzlHdF/0K72cH/4BRgJTpPWGY=",
         "owner": "asmap",
         "repo": "rpki-client-nix",
-        "rev": "b9b68b6d4b8170213c741362797ea13029913222",
+        "rev": "0a01e84611e878394a6453e5ac572ad736418230",
         "type": "github"
       },
       "original": {
@@ -109,21 +108,6 @@
         "type": "github"
       }
     },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "utils": {
       "inputs": {
         "systems": "systems"
@@ -134,24 +118,6 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
-    utils.url = "github:numtide/flake-utils";
     # the rpki-client binary will be built from the flake at this URL.
     rpki-cli.url = "github:asmap/rpki-client-nix";
   };
@@ -11,73 +10,45 @@
   outputs = {
     self,
     nixpkgs,
-    utils,
     rpki-cli,
-  }:
-    # Add a kartograf module for NixOS (see module.nix for details)
-    { nixosModules.kartograf = import ./module.nix self; } //
-    # Build for all default systems: ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"]
-    utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
+  }: let
+    forAllSystems = nixpkgs.lib.genAttrs [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
 
-      rpki-client = rpki-cli.defaultPackage.${system};
-      pythonBuildDeps = pkgs.python311.withPackages (ps: [
-        ps.beautifulsoup4
-        ps.pandas
-        ps.requests
-        ps.tqdm
-      ]);
+    nixpkgsFor = system: import nixpkgs { inherit system;};
+  in {
+    # This flake exposes the following attributes:
+    # * A development shell containing the rpki-client and the necessary
+    #   Python env and packages to run kartograf. To use, run 'nix develop'
+    #   in the current directory.
+    # * A default/kartograf package
+    # * A NixOS module
+    devShells.default = forAllSystems (system: let
+      pkgs = nixpkgsFor system;
       pythonDevDeps = pkgs.python311.withPackages (ps: [
-        ps.beautifulsoup4
-        ps.pandas
-        ps.requests
-        ps.tqdm
-      ]);
-      kartografDeps = [
-        pythonBuildDeps
-        rpki-client
-      ];
-    in {
-      # This flake exposes the following attributes:
-      # * A development shell containing the rpki-client and the necessary
-      #   Python env and packages to run kartograf. To use, run 'nix develop'
-      #   in the current directory.
-      # * A default/kartograf package
-      # * A NixOS module
-      devShells.default = pkgs.mkShell {
-        packages = [rpki-client pythonDevDeps];
+          ps.beautifulsoup4
+          ps.pandas
+          ps.requests
+          ps.tqdm
+        ]);
+    in
+      pkgs.mkShell {
+        packages = [pythonDevDeps rpki-cli.defaultPackage.${system}];
+      });
+
+    packages = forAllSystems (system: let
+      pkgs = nixpkgsFor system;
+    in rec {
+      kartograf = pkgs.callPackage ./package.nix {
+        rpki-client = rpki-cli.defaultPackage.${system};
       };
-      packages = {
-        kartograf = pkgs.stdenv.mkDerivation {
-          # not a python-installable package, so just manually copy files
-          pname = "kartograf";
-          version = "1.0.0";
-          src = ./.;
-          nativeBuildInputs = [pkgs.makeWrapper];
-          buildInputs = kartografDeps;
-          propagatedBuildInputs = [rpki-client];
-          buildPhase = ''
-            mkdir -p $out/lib/kartograf
-            cp -r ${./kartograf}/* $out/lib/kartograf/
-          '';
-          installPhase = ''
-            mkdir -p $out/bin
-            cp ${./run} $out/bin/kartograf
-            chmod +x $out/bin/kartograf
-          '';
-          fixupPhase = ''
-            wrapProgram $out/bin/kartograf \
-              --set PYTHONPATH $out/lib:$PYTHONPATH
-            wrapProgram $out/bin/kartograf \
-              --set PATH ${rpki-cli.defaultPackage.${system}}/bin:$PATH
-          '';
-          meta = with pkgs.lib; {
-            description = "Kartograf: IP to ASN mapping for everyone";
-            license = licenses.mit;
-            homepage = "https://github.com/asmap/kartograf";
-          };
-        };
-        default = self.packages.${system}.kartograf;
-      };
+      default = kartograf;
     });
+
+    nixosModules.default = import ./module.nix;
+  };
 }

--- a/module.nix
+++ b/module.nix
@@ -1,9 +1,8 @@
-flake: { config, pkgs, lib, ... }:
+{ config, pkgs, lib, ... }:
 
 with lib;
 
 let
-  inherit (flake.packages.${pkgs.stdenv.hostPlatform.system}) kartograf;
   cfg = config.services.kartograf;
   postScript = pkgs.writeScriptBin "post-script" /* bash */ ''
     #!/${pkgs.bash}/bin/bash

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,38 @@
+{pkgs, rpki-client }:
+let
+      pythonBuildDeps = pkgs.python311.withPackages (ps: [
+        ps.beautifulsoup4
+        ps.pandas
+        ps.requests
+        ps.tqdm
+      ]);
+in
+        pkgs.stdenv.mkDerivation {
+          # not a python-installable package, so just manually copy files
+          pname = "kartograf";
+          version = "1.0.0";
+          src = ./.;
+          nativeBuildInputs = [pkgs.makeWrapper];
+          buildInputs = [ pythonBuildDeps ];
+          propagatedBuildInputs = [ rpki-client ];
+          buildPhase = ''
+            mkdir -p $out/lib/kartograf
+            cp -r ${./kartograf}/* $out/lib/kartograf/
+          '';
+          installPhase = ''
+            mkdir -p $out/bin
+            cp ${./run} $out/bin/kartograf
+            chmod +x $out/bin/kartograf
+          '';
+          fixupPhase = ''
+            wrapProgram $out/bin/kartograf \
+              --set PYTHONPATH $out/lib:$PYTHONPATH
+            wrapProgram $out/bin/kartograf \
+              --set PATH ${rpki-client}/bin:$PATH
+          '';
+          meta = with pkgs.lib; {
+            description = "Kartograf: IP to ASN mapping for everyone";
+            license = licenses.mit;
+            homepage = "https://github.com/asmap/kartograf";
+          };
+        }


### PR DESCRIPTION
Besides removing a dependency for the project, this refactors the flake to be a bit cleaner.

Using `flake-utils` makes expressing "for each system" type expression simple, but it also gets in the way of items that don't need this type of expression, such as the `module.nix`. Thus we had to define an improper module expression, which makes _using_ the module in another expression more complicated as well. 

So instead we create `forAllSystems` and `nixpkgsFor` functions explicitly. This means a little more involved package expressions, but that hide less from the user. The module can now be `import`'ed and it can be used as a module in other machine configurations without extra treatment. I stole this idea from [this](https://ayats.org/blog/no-flake-utils).

I also took the opportunity to split out the main package expression into its own file, for clarity. 