### PR TITLE
bump nixpkgs to 24.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727264057,
-        "narHash": "sha256-KQPI8CTTnB9CrJ7LrmLC4VWbKZfljEPBXOFGZFRpxao=",
+        "lastModified": 1732350895,
+        "narHash": "sha256-GcOQbOgmwlsRhpLGSwZJwLbo3pu9ochMETuRSS1xpz4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "759537f06e6999e141588ff1c9be7f3a5c060106",
+        "rev": "0c582677378f2d9ffcb01490af2f2c678dcb29d3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "An IP-to-AS mapping tool.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     utils.url = "github:numtide/flake-utils";
     # the rpki-client binary will be built from the flake at this URL.
     rpki-cli.url = "github:asmap/rpki-client-nix";
@@ -30,9 +30,9 @@
       pythonDevDeps = pkgs.python311.withPackages (ps: [
         ps.beautifulsoup4
         ps.pandas
+        ps.pylint
         ps.requests
         ps.tqdm
-        ps.pylint
       ]);
       kartografDeps = [
         pythonBuildDeps


### PR DESCRIPTION
24.11 was released [today](https://discourse.nixos.org/t/nixos-24-11-released/56811). The following package upgrades are relevant to us:

pylint 3.1.1 -> 3.3.1
pandas 2.2.1 -> 2.2.3