### PR TITLE
bump pandas requirement to >=2.2.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4==4.11.1
-pandas==1.5.3
+pandas>=2.2.3
 requests>=2.31.0
 tqdm==4.66.3


### PR DESCRIPTION
Our current version is fairly old (released Jan 2023). This version is 3 months old and should be a safe requirement for a while. It also aligns with nixpkgs 24.11.

From discussion in #32 