### PR TITLE
split out dev package requirements and adjust CI accordingly

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pylint
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Run Pylint
         run: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pylint==3.3.1
+pytest==8.3.3


### PR DESCRIPTION
Add `pylint` and `pytest` to a separate requirements file for dev and CI purposes.