### PR TITLE
Test the Context class

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,11 @@
 import pytest
-from kartograf.cli import create_parser
+from kartograf.cli import create_parser, main
 
-parser = create_parser()
+@pytest.fixture(name="parser")
+def fixture_parser():
+    return create_parser()
 
-def test_map_command():
+def test_map_command(parser):
     args = parser.parse_args(['map'])
     assert args.command == 'map'
     assert args.debug is True  # default is True
@@ -14,7 +16,7 @@ def test_map_command():
     assert args.epoch is None
     assert args.max_encode == 33521664
 
-def test_map_with_options():
+def test_map_with_options(parser):
     args = parser.parse_args(['map', '-c', '-irr', '-rv', '-r', '/path', '-t', '123'])
     assert args.cleanup is True
     assert args.irr is True
@@ -22,27 +24,34 @@ def test_map_with_options():
     assert args.reproduce == '/path'
     assert args.epoch == '123'
 
-def test_merge_command():
+def test_merge_command(parser):
     args = parser.parse_args(['merge'])
     assert args.command == 'merge'
     assert args.base.endswith('base_file.txt')
     assert args.extra.endswith('extra_file.txt')
     assert args.output.endswith('out_file.txt')
 
-def test_cov_command(capsys):
+def test_cov_command(parser, capsys):
     with pytest.raises(SystemExit):
         # Should fail without required arguments
         parser.parse_args(['cov'])
     captured = capsys.readouterr()
     assert captured.err.startswith("usage:")
 
-def test_invalid_command(capsys):
+def test_help(capsys):
+    with pytest.raises(SystemExit) as e:
+        main([])
+    assert e.value.code == "Please provide a command."
+    captured = capsys.readouterr()
+    assert captured.out.startswith("usage:")
+
+def test_invalid_command(parser, capsys):
     with pytest.raises(SystemExit):
         parser.parse_args(['invalid'])
     captured = capsys.readouterr()
     assert captured.err.startswith("usage:")
 
-def test_version_flag(capsys):
+def test_version_flag(parser, capsys):
     with pytest.raises(SystemExit) as excinfo:
         parser.parse_args(['--version'])
     assert excinfo.value.code == 0

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,0 +1,62 @@
+import os
+import pytest
+from kartograf.context import Context
+from kartograf.cli import create_parser
+
+@pytest.fixture(name="parser")
+def fixture_parser():
+    return create_parser()
+
+def test_basic_map_context(parser, tmp_path):
+    args = parser.parse_args(['map'])
+    os.chdir(tmp_path)  # Use temporary directory
+    context = Context(args)
+
+    assert context.args.command == 'map'
+    assert context.reproduce is False
+    assert context.args.debug is True
+    assert context.args.cleanup is False
+    assert context.args.irr is False
+    assert context.args.routeviews is False
+    assert isinstance(context.epoch, str)
+    assert isinstance(int(context.epoch), int)
+    assert context.max_encode == 33521664
+    assert context.debug_log.endswith('debug.log')
+
+def test_map_context_with_reproduce(parser, tmp_path):
+    # Setup a mock reproduction directory
+    repro_path = tmp_path / "repro"
+    repro_path.mkdir()
+    (repro_path / "irr").mkdir()
+    (repro_path / "collectors").mkdir()
+
+    args = parser.parse_args(['map', '-r', str(repro_path), '-t', '1225411200'])
+    context = Context(args)
+
+    assert context.reproduce is True
+    assert context.epoch == '1225411200'
+    assert context.epoch_dir == 'r1225411200'
+    assert context.args.irr is True  # Should be True since irr dir exists
+    assert context.args.routeviews is True  # Should be True since collectors dir exists
+
+def test_map_context_with_wait(parser, tmp_path):
+    args = parser.parse_args(['map', '-w', '1225411200'])
+    os.chdir(tmp_path)
+    context = Context(args)
+
+    assert context.epoch == '1225411200'
+    assert context.epoch_dir == '1225411200'
+    assert not context.reproduce
+
+def test_directory_creation(parser, tmp_path):
+    args = parser.parse_args(['map', '-irr', '-rv'])
+    os.chdir(tmp_path)
+    context = Context(args)
+
+    assert os.path.exists(context.data_dir_rpki_cache)
+    assert os.path.exists(context.data_dir_rpki_tals)
+    assert os.path.exists(context.data_dir_irr)
+    assert os.path.exists(context.data_dir_collectors)
+    assert os.path.exists(context.out_dir_rpki)
+    assert os.path.exists(context.out_dir_irr)
+    assert os.path.exists(context.out_dir_collectors)


### PR DESCRIPTION
use pytest fixtures for the parser, update `test_cli.py` with this approach

Also adds a CLI test for empty args.

stacked on #42 