### PR TITLE
Bump rpki-client tested/recommended version to 9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ to enable flakes in your Nix config, then run `nix develop`.
 
 #### rpki-client
 
-Kartograf requires `rpki-client` version 8.4 or higher to be installed locally. Many package managers have `rpki-client`, however please note that typically only the latest version is available. Kartograf is currently tested to work with `rpki-client` 8.4 - 9.3. If a new release is available that breaks compatibility, you may need to build a compatible `rpki-client` version yourself if your preferred package manager does not have a compatible version available. In that case, see the [instructions in the rpki-client-portable project](https://github.com/rpki-client/rpki-client-portable/blob/master/INSTALL).
+Kartograf requires `rpki-client` version 8.4 or higher to be installed locally. Many package managers have `rpki-client`, however please note that typically only the latest version is available. Kartograf is currently tested to work with `rpki-client` 8.4 - 9.4. If a new release is available that breaks compatibility, you may need to build a compatible `rpki-client` version yourself if your preferred package manager does not have a compatible version available. In that case, see the [instructions in the rpki-client-portable project](https://github.com/rpki-client/rpki-client-portable/blob/master/INSTALL).
 
 ```
 # Linux/BSD

--- a/kartograf/util.py
+++ b/kartograf/util.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 import time
 
-RPKI_VERSION = 9.3
+RPKI_VERSION = 9.4
 
 
 def calculate_sha256(file_path):


### PR DESCRIPTION
I have tested both new runs and reproduction runs and didn't see any issues. See their release page for more info: https://github.com/rpki-client/rpki-client-portable/releases/tag/9.4

@jurraca can you please take care of bumping the nix module? Thanks!