### PR TITLE
bug fix: checking reproduce and epoch args logic

### DIFF
--- a/kartograf/cli.py
+++ b/kartograf/cli.py
@@ -81,8 +81,8 @@ def main(args=None):
     parser = create_parser()
     args = parser.parse_args(args)
 
-    if args.command == "run":
-        if args.reproduce and not args.epoch:
+    if args.command == "map":
+        if not args.reproduce and args.epoch:
             parser.error("--reproduce is required when --epoch is set.")
         elif not args.epoch and args.reproduce:
             parser.error("--epoch is required when --reproduce is set.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,23 @@ def test_map_command(parser):
     assert args.epoch is None
     assert args.max_encode == 33521664
 
+def test_reproduce_args_failure(capsys):
+    '''
+    Both --reproduce and --epoch must be set if either one is set.
+    A usage help text is returned with the error.
+    '''
+    args = ['map', '-r', '/path']
+    with pytest.raises(SystemExit):
+        main(args)
+    captured = capsys.readouterr()
+    assert captured.err.startswith("usage:")
+
+    args = ['map', '-t', '123456789']
+    with pytest.raises(SystemExit):
+        main(args)
+    captured = capsys.readouterr()
+    assert captured.err.startswith("usage:")
+
 def test_map_with_options(parser):
     args = parser.parse_args(['map', '-c', '-irr', '-rv', '-r', '/path', '-t', '123'])
     assert args.cleanup is True


### PR DESCRIPTION
A bug I noticed while testing: the check that both `reproduce` and `epoch` args only occur together is broken since this [commit](https://github.com/asmap/kartograf/commit/1b6bc2136dc0efca9d87652a915290cf709341d6). The commit intended to ensure that we print the help text when no arguments were provided, but it did not include any tests, which was a mistake on my part and would have caught this. 
The `command` to check here is `map` not `run`. The logical operator was also wrong for the intended check.
The test checks the lack of both arguments, and that a helpful usage text is show to the user.