### PR TITLE
context: use pathlib instead of os.path

### DIFF
--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from typing import Dict
 
 from kartograf.bogon import (
@@ -12,8 +13,8 @@ from kartograf.util import parse_pfx
 
 @timed
 def parse_rpki(context):
-    raw_input = f"{context.out_dir_rpki}rpki_raw.json"
-    rpki_res = f"{context.out_dir_rpki}rpki_final.txt"
+    raw_input = Path(context.out_dir_rpki) / "rpki_raw.json"
+    rpki_res = Path(context.out_dir_rpki) / "rpki_final.txt"
 
     output_cache: Dict[str, [str, str]] = {}
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import pytest
 from kartograf.context import Context
 from kartograf.cli import create_parser
@@ -21,7 +22,7 @@ def test_basic_map_context(parser, tmp_path):
     assert isinstance(context.epoch, str)
     assert isinstance(int(context.epoch), int)
     assert context.max_encode == 33521664
-    assert context.debug_log.endswith('debug.log')
+    assert Path(context.debug_log).name == 'debug.log'
 
 def test_map_context_with_reproduce(parser, tmp_path):
     # Setup a mock reproduction directory
@@ -53,10 +54,17 @@ def test_directory_creation(parser, tmp_path):
     os.chdir(tmp_path)
     context = Context(args)
 
-    assert os.path.exists(context.data_dir_rpki_cache)
-    assert os.path.exists(context.data_dir_rpki_tals)
-    assert os.path.exists(context.data_dir_irr)
-    assert os.path.exists(context.data_dir_collectors)
-    assert os.path.exists(context.out_dir_rpki)
-    assert os.path.exists(context.out_dir_irr)
-    assert os.path.exists(context.out_dir_collectors)
+    assert isinstance(context.data_dir_rpki_cache, str)
+    assert Path(context.data_dir_rpki_cache).exists()
+    assert isinstance(context.data_dir_rpki_tals, str)
+    assert Path(context.data_dir_rpki_tals).exists()
+    assert isinstance(context.data_dir_irr, str)
+    assert Path(context.data_dir_irr).exists()
+    assert isinstance(context.data_dir_collectors, str)
+    assert Path(context.data_dir_collectors).exists()
+    assert isinstance(context.out_dir_rpki, str)
+    assert Path(context.out_dir_rpki).exists()
+    assert isinstance(context.out_dir_irr, str)
+    assert Path(context.out_dir_irr).exists()
+    assert isinstance(context.out_dir_collectors, str)
+    assert Path(context.out_dir_collectors).exists()

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -40,10 +40,10 @@ def test_merge_from_fixtures(tmp_path):
     and validates against expected networks,
     i.e. subnets are merged into the root network appropriately.
     '''
-    testdir = Path(__file__).parent
-    base_nets, base_results = __read_test_vectors(testdir / "data/base_file.csv")
+    data_dir = Path(__file__).parent / "data"
+    base_nets, base_results = __read_test_vectors(data_dir / "base_file.csv")
     base_path = tmp_path / "base.txt"
-    extra_nets, extra_results = __read_test_vectors(testdir / "data/extra_file.csv")
+    extra_nets, extra_results = __read_test_vectors(data_dir / "extra_file.csv")
     extra_path = tmp_path / "extra.txt"
     # write the networks to disk, generating ASNs for each network
     generate_ip_file(base_path, build_file_lines(base_nets, generate_asns(len(base_nets))))


### PR DESCRIPTION
f-strings require getting the path slashes correct manually, so pathlib is better here, albeit more verbose and having to cast paths back to strings. Adds isinstance tests for context fields. 

There's more path instances to be fixed elsewhere but this is a first pass done in handling #49 .