### PR TITLE
Bugfix for path concatenation

### DIFF
--- a/kartograf/collectors/parse.py
+++ b/kartograf/collectors/parse.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from kartograf.bogon import (
     is_bogon_pfx,
     is_bogon_asn,
@@ -9,8 +11,8 @@ from kartograf.util import parse_pfx
 
 @timed
 def parse_routeviews_pfx2as(context):
-    raw_file = f'{context.out_dir_collectors}pfx2asn.txt'
-    clean_file = f'{context.out_dir_collectors}pfx2asn_clean.txt'
+    raw_file = Path(context.out_dir_collectors) / "pfx2asn.txt"
+    clean_file = Path(context.out_dir_collectors) / "pfx2asn_clean.txt"
 
     print("Cleaning " + raw_file)
     with open(raw_file, 'r') as raw, open(clean_file, 'w') as clean:

--- a/kartograf/collectors/parse.py
+++ b/kartograf/collectors/parse.py
@@ -14,7 +14,7 @@ def parse_routeviews_pfx2as(context):
     raw_file = Path(context.out_dir_collectors) / "pfx2asn.txt"
     clean_file = Path(context.out_dir_collectors) / "pfx2asn_clean.txt"
 
-    print("Cleaning " + raw_file)
+    print("Cleaning " + str(raw_file))
     with open(raw_file, 'r') as raw, open(clean_file, 'w') as clean:
         lines = raw.readlines()
         for line in lines:

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from pathlib import Path
 import gzip
 import shutil
 import sys
@@ -67,8 +68,8 @@ def download(url, file):
 
 
 def extract(file, context):
-    gz_file = context.data_dir_collectors + file + ".gz"
-    file = context.out_dir_collectors + file
+    gz_file = Path(context.data_dir_collectors) / (file + ".gz")
+    file = Path(context.out_dir_collectors) / file
 
     print(f'Unzipping {gz_file}')
     with gzip.open(gz_file, 'rb') as f_in:
@@ -88,9 +89,9 @@ def extract(file, context):
 
 @timed
 def fetch_routeviews_pfx2as(context):
-    path = context.data_dir_collectors
-    v4_file_gz = f'{path}routeviews_pfx2asn_ip4.txt.gz'
-    v6_file_gz = f'{path}routeviews_pfx2asn_ip6.txt.gz'
+    path = Path(context.data_dir_collectors)
+    v4_file_gz = path / "routeviews_pfx2asn_ip4.txt.gz"
+    v6_file_gz = path / "routeviews_pfx2asn_ip6.txt.gz"
 
     download(latest_link(PFX2AS_V4), v4_file_gz)
     print(f"Downloaded {v4_file_gz}, file hash: {calculate_sha256(v4_file_gz)}")
@@ -105,9 +106,9 @@ def extract_routeviews_pfx2as(context):
     extract(v4_file_name, context)
     extract(v6_file_name, context)
 
-    v4_file = context.out_dir_collectors + v4_file_name
-    v6_file = context.out_dir_collectors + v6_file_name
-    out_file = f'{context.out_dir_collectors}pfx2asn.txt'
+    v4_file = Path(context.out_dir_collectors) / v4_file_name
+    v6_file = Path(context.out_dir_collectors) / v6_file_name
+    out_file = Path(context.out_dir_collectors) / "pfx2asn.txt"
 
     with open(v4_file, 'r') as v4, \
             open(v6_file, 'r') as v6, \

--- a/kartograf/irr/fetch.py
+++ b/kartograf/irr/fetch.py
@@ -2,6 +2,7 @@ from ftplib import FTP
 import gzip
 import shutil
 import time
+from pathlib import Path
 
 from kartograf.timed import timed
 from kartograf.util import calculate_sha256
@@ -31,7 +32,7 @@ def fetch_irr(context):
         host, ftp_file_path = ftp_file.split("/", 1)
         path, file_name = ftp_file_path.rsplit("/", 1)
 
-        local_file_path = context.data_dir_irr + file_name
+        local_file_path = Path(context.data_dir_irr) / file_name
         attempt = 0
 
         print("Downloading " + file_name)
@@ -60,8 +61,8 @@ def extract_irr(context):
     for ftp_file in IRR_FILE_ADDRESSES:
         _, ftp_file_path = ftp_file.split("/", 1)
         _, file_name = ftp_file_path.rsplit("/", 1)
-        local_file_path = context.data_dir_irr + file_name
-        extracted_file_path = context.out_dir_irr + file_name.rstrip(".gz")
+        local_file_path = Path(context.data_dir_irr) / file_name
+        extracted_file_path = Path(context.out_dir_irr) / file_name.rstrip(".gz")
 
         print("Extracting " + file_name)
         with gzip.open(local_file_path, 'rb') as r:

--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -1,7 +1,7 @@
 import codecs
 from datetime import datetime, timezone
 import os
-import pathlib
+from pathlib import Path
 from typing import Dict
 
 from kartograf.bogon import (
@@ -15,9 +15,9 @@ from kartograf.util import parse_pfx, rir_from_str
 
 @timed
 def parse_irr(context):
-    irr_res = f"{context.out_dir_irr}irr_final.txt"
+    irr_res = Path(context.out_dir_irr) / "irr_final.txt"
 
-    irr_files = [path for path in pathlib.Path(context.out_dir_irr).rglob('*')
+    irr_files = [path for path in Path(context.out_dir_irr).rglob('*')
                  if os.path.isfile(path)
                  and (os.path.splitext(path)[1] != ".gz")]
 

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import ipaddress
 import shutil
 import pandas as pd
@@ -62,10 +63,10 @@ class BaseNetworkIndex:
 
 @timed
 def merge_irr(context):
-    rpki_file = f"{context.out_dir_rpki}rpki_final.txt"
-    irr_file = f"{context.out_dir_irr}irr_final.txt"
-    irr_filtered_file = f"{context.out_dir_irr}irr_filtered.txt"
-    out_file = f"{context.out_dir}merged_file_rpki_irr.txt"
+    rpki_file = Path(context.out_dir_rpki) / "rpki_final.txt"
+    irr_file = Path(context.out_dir_irr) / "irr_final.txt"
+    irr_filtered_file = Path(context.out_dir_irr) / "irr_filtered.txt"
+    out_file = Path(context.out_dir) / "merged_file_rpki_irr.txt"
 
     general_merge(
         rpki_file,
@@ -81,14 +82,14 @@ def merge_pfx2as(context):
     # We are always doing RPKI but IRR is optional for now so depending on this
     # we are working off of a different base file for the merge.
     if context.args.irr:
-        base_file = f"{context.out_dir}merged_file_rpki_irr.txt"
-        out_file = f"{context.out_dir}merged_file_rpki_irr_rv.txt"
+        base_file = Path(context.out_dir) / "merged_file_rpki_irr.txt"
+        out_file = Path(context.out_dir) / "merged_file_rpki_irr_rv.txt"
     else:
-        base_file = f"{context.out_dir_rpki}rpki_final.txt"
-        out_file = f"{context.out_dir}merged_file_rpki_rv.txt"
+        base_file = Path(context.out_dir_rpki) / "rpki_final.txt"
+        out_file = Path(context.out_dir) / "merged_file_rpki_rv.txt"
 
-    rv_file = f"{context.out_dir_collectors}pfx2asn_clean.txt"
-    rv_filtered_file = f"{context.out_dir_collectors}pfx2asn_filtered.txt"
+    rv_file = Path(context.out_dir_collectors) / "pfx2asn_clean.txt"
+    rv_filtered_file = Path(context.out_dir_collectors) / "pfx2asn_filtered.txt"
 
     general_merge(
         base_file,

--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -3,8 +3,7 @@ import sys
 
 from concurrent.futures import ThreadPoolExecutor
 from threading import Lock
-import os
-import pathlib
+from pathlib import Path
 import requests
 from tqdm import tqdm
 
@@ -31,7 +30,7 @@ def download_rir_tals(context):
             response = requests.get(url, timeout=600)
             response.raise_for_status()
 
-            tal_path = os.path.join(context.data_dir_rpki_tals, f"{rir}.tal")
+            tal_path = Path(context.data_dir_rpki_tals) / f"{rir}.tal"
             with open(tal_path, 'wb') as file:
                 file.write(response.content)
 
@@ -44,7 +43,7 @@ def download_rir_tals(context):
 
 
 def data_tals(context):
-    tal_paths = list(pathlib.Path(context.data_dir_rpki_tals).rglob('*.tal'))
+    tal_paths = list(Path(context.data_dir_rpki_tals).rglob('*.tal'))
     # We need to have 5 TALs, one from each RIR
     if len(tal_paths) == 5:
         return tal_paths
@@ -82,13 +81,13 @@ def fetch_rpki_db(context):
 @timed
 def validate_rpki_db(context):
     print("Validating RPKI ROAs")
-    files = [path for path in pathlib.Path(context.data_dir_rpki_cache).rglob('*')
+    files = [path for path in Path(context.data_dir_rpki_cache).rglob('*')
              if path.is_file() and ((path.suffix == ".roa")
                                     or (path.name == ".roa"))]
 
     print(f"{len(files)} raw RKPI ROA files found.")
     rpki_raw_file = 'rpki_raw.json'
-    result_path = f"{context.out_dir_rpki}{rpki_raw_file}"
+    result_path = Path(context.out_dir_rpki) / rpki_raw_file
 
     tal_options = [item for path in data_tals(context) for item in ('-t', path)]
 

--- a/kartograf/sort.py
+++ b/kartograf/sort.py
@@ -1,4 +1,5 @@
 import ipaddress
+from pathlib import Path
 import shutil
 
 from kartograf.timed import timed
@@ -7,13 +8,13 @@ from kartograf.timed import timed
 @timed
 def sort_result_by_pfx(context):
     if context.args.irr and context.args.routeviews:
-        out_file = f"{context.out_dir}merged_file_rpki_irr_rv.txt"
+        out_file = Path(context.out_dir) / "merged_file_rpki_irr_rv.txt"
     elif context.args.irr:
-        out_file = f"{context.out_dir}merged_file_rpki_irr.txt"
+        out_file = Path(context.out_dir) / "merged_file_rpki_irr.txt"
     elif context.args.routeviews:
-        out_file = f"{context.out_dir}merged_file_rpki_rv.txt"
+        out_file = Path(context.out_dir) / "merged_file_rpki_rv.txt"
     else:
-        out_file = f"{context.out_dir_rpki}rpki_final.txt"
+        out_file = Path(context.out_dir_rpki) / "rpki_final.txt"
 
     with open(out_file, 'r') as file:
         prefixes = file.read().splitlines()
@@ -35,7 +36,7 @@ def sort_result_by_pfx(context):
 
     sortable_prefixes.sort()
 
-    sorted_out_file = f"{context.out_dir}merged_file_sorted.txt"
+    sorted_out_file = Path(context.out_dir) / "merged_file_sorted.txt"
     with open(sorted_out_file, "w") as file:
         for is_ipv6, net_int, neg_prefixlen, asn in sortable_prefixes:
             prefixlen = -neg_prefixlen

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -54,17 +54,37 @@ def test_directory_creation(parser, tmp_path):
     os.chdir(tmp_path)
     context = Context(args)
 
-    assert isinstance(context.data_dir_rpki_cache, str)
-    assert Path(context.data_dir_rpki_cache).exists()
-    assert isinstance(context.data_dir_rpki_tals, str)
-    assert Path(context.data_dir_rpki_tals).exists()
-    assert isinstance(context.data_dir_irr, str)
-    assert Path(context.data_dir_irr).exists()
-    assert isinstance(context.data_dir_collectors, str)
-    assert Path(context.data_dir_collectors).exists()
-    assert isinstance(context.out_dir_rpki, str)
-    assert Path(context.out_dir_rpki).exists()
-    assert isinstance(context.out_dir_irr, str)
-    assert Path(context.out_dir_irr).exists()
-    assert isinstance(context.out_dir_collectors, str)
-    assert Path(context.out_dir_collectors).exists()
+    rpki_cache = context.data_dir_rpki_cache
+    assert isinstance(rpki_cache, str)
+    assert Path(rpki_cache).exists()
+    assert Path(rpki_cache).parent.name == "rpki"
+
+    rpki_tals = context.data_dir_rpki_tals
+    assert isinstance(rpki_tals, str)
+    assert Path(rpki_tals).exists()
+    assert Path(rpki_tals).parent.name == "rpki"
+
+    data_dir_irr = context.data_dir_irr
+    assert isinstance(data_dir_irr, str)
+    assert Path(data_dir_irr).exists()
+    assert Path(data_dir_irr).name == "irr"
+
+    data_dir_collectors = context.data_dir_collectors
+    assert isinstance(data_dir_collectors, str)
+    assert Path(data_dir_collectors).exists()
+    assert Path(data_dir_collectors).name == "collectors"
+
+    out_dir_rpki = context.out_dir_rpki
+    assert isinstance(out_dir_rpki, str)
+    assert Path(out_dir_rpki).exists()
+    assert Path(out_dir_rpki).name == "rpki"
+
+    out_dir_irr = context.out_dir_irr
+    assert isinstance(out_dir_irr, str)
+    assert Path(out_dir_irr).exists()
+    assert Path(out_dir_irr).name == "irr"
+
+    out_dir_collectors = context.out_dir_collectors
+    assert isinstance(out_dir_collectors, str)
+    assert Path(out_dir_collectors).exists()
+    assert Path(out_dir_collectors).name == "collectors"


### PR DESCRIPTION
The [latest commit](https://github.com/asmap/kartograf/commit/b6c630eeb9177dd2bd2b14d5e685e483be562fa8) on master (using pathlib to do path concatenation in the context) breaks every other path concatenation step in other modules. 

I should have done this in one go. Unfortunately, better tests would only have caught some of these issues. The context test is updated here, but we'll need to think about how to test other file handling during the fetching and merge, since file generation and lookup happen outside the context, for example in `collectors/routeviews.py`. This PR should cover all the instances of path concatenation for files in the app though.

I only caught this by doing a full run, and I'll do that for each change moving forward until we have more tests in place.