### PR TITLE
IRR parsing tests: add fixtures and basic test, update context

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -45,9 +45,13 @@ def load_irr_fixtures(context, fixtures_path):
     for file in irr_fixtures():
         shutil.copy2(Path(fixtures_path) / file, context.out_dir_irr)
 
+def setup_test_data(context):
+    fixtures_path = Path(__file__).parent / "data"
+    load_rpki_csv_to_json(context, fixtures_path)
+    load_irr_fixtures(context, fixtures_path)
+
 def create_test_context(tmp_path, epoch):
     current_path = Path.cwd()
-    fixtures_path = Path(__file__).parent / "data"
     os.chdir(tmp_path)  # Use temporary directory
 
     TEST_ARGS.epoch = epoch
@@ -62,7 +66,5 @@ def create_test_context(tmp_path, epoch):
     for p in [context.data_dir_rpki, context.data_dir_irr, context.out_dir_rpki, context.out_dir_irr]:
         Path.mkdir(p, exist_ok=True, parents=True)
 
-    load_rpki_csv_to_json(context, fixtures_path)
-    load_irr_fixtures(context, fixtures_path)
     os.chdir(current_path)
     return context

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,8 +1,8 @@
 import csv
 import json
 import os
+import shutil
 from pathlib import Path
-
 from types import SimpleNamespace
 from kartograf.context import Context
 
@@ -17,11 +17,15 @@ TEST_ARGS = SimpleNamespace(**{
     "epoch": None
 })
 
+def irr_fixtures():
+    return [ "irr_ripe.txt" ]
 
-def load_rpki_csv_to_json(self, csv_path):
+
+def load_rpki_csv_to_json(context, fixtures_path):
     '''
     Loads a fixtures CSV file into a rpki_raw.json file in the "tests/out/" directory.
     '''
+    csv_path = fixtures_path / "rpki_raw.csv"
     rpki_data = []
     with open(csv_path, 'r') as csvfile:
         reader = csv.DictReader(csvfile)
@@ -33,10 +37,13 @@ def load_rpki_csv_to_json(self, csv_path):
             row["vrps"] = vrps
             rpki_data.append(row)
 
-    output_path = Path(self.out_dir_rpki) / 'rpki_raw.json'
+    output_path = Path(context.out_dir_rpki) / 'rpki_raw.json'
     with open(output_path, 'w') as jsonfile:
         json.dump(rpki_data, jsonfile, indent=2)
 
+def load_irr_fixtures(context, fixtures_path):
+    for file in irr_fixtures():
+        shutil.copy2(Path(fixtures_path) / file, context.out_dir_irr)
 
 def create_test_context(tmp_path, epoch):
     current_path = Path.cwd()
@@ -47,12 +54,15 @@ def create_test_context(tmp_path, epoch):
     context = Context(TEST_ARGS)
     context.data_dir = Path(tmp_path) / "data" / context.epoch_dir
     context.data_dir_rpki = Path(context.data_dir) / "rpki"
+    context.data_dir_irr = Path(context.data_dir) / "irr"
     context.out_dir = Path(tmp_path) / "out" / context.epoch_dir
     context.out_dir_rpki = Path(context.out_dir) / "rpki"
+    context.out_dir_irr = Path(context.out_dir) / "irr"
 
-    Path.mkdir(context.data_dir_rpki, exist_ok=True, parents=True)
-    Path.mkdir(context.out_dir_rpki, exist_ok=True, parents=True)
+    for p in [context.data_dir_rpki, context.data_dir_irr, context.out_dir_rpki, context.out_dir_irr]:
+        Path.mkdir(p, exist_ok=True, parents=True)
 
-    load_rpki_csv_to_json(context, fixtures_path / "rpki_raw.csv")
+    load_rpki_csv_to_json(context, fixtures_path)
+    load_irr_fixtures(context, fixtures_path)
     os.chdir(current_path)
     return context

--- a/tests/data/irr_ripe.txt
+++ b/tests/data/irr_ripe.txt
@@ -1,0 +1,52 @@
+route:          193.254.30.0/24
+descr:          Lufthansa Airplus Servicekarten GmbH
+origin:         AS12726
+mnt-by:         AS12312-MNT
+mnt-by:         DE-COLT-MNT
+mnt-by:         COLT-UK
+created:        2002-05-21T15:33:55Z
+last-modified:  2024-07-30T07:55:18Z
+source:         RIPE
+remarks:        ****************************
+remarks:        * THIS OBJECT IS MODIFIED
+remarks:        * Please note that all data that is generally regarded as personal
+remarks:        * data has been removed from this object.
+remarks:        * To view the original object, please query the RIPE Database at:
+remarks:        * http://www.ripe.net/whois
+remarks:        ****************************
+
+route:          212.166.64.0/19
+descr:          Tiscali Spain
+origin:         AS12321
+mnt-by:         TISCALI-ES-MNT
+notify:         noc@ibercom.com
+notify:         david.barbarin@ibercom.com
+created:        2002-02-22T11:45:51Z
+last-modified:  2015-11-03T09:29:04Z
+source:         RIPE
+remarks:        ****************************
+remarks:        * THIS OBJECT IS MODIFIED
+remarks:        * Please note that all data that is generally regarded as personal
+remarks:        * data has been removed from this object.
+remarks:        * To view the original object, please query the RIPE Database at:
+remarks:        * http://www.ripe.net/whois
+remarks:        ****************************
+
+route:          212.80.191.0/24
+descr:          Cable&Wireless EUROPE
+descr:          assigned internal use
+origin:         AS12541
+notify:         ipadmin@cweurope.net
+notify:         aaron.hamilton@cweurope.net
+mnt-by:         EVOLUTIOCLOUD-MNT
+created:        1970-01-01T00:00:00Z
+last-modified:  2023-06-05T20:59:06Z
+source:         RIPE
+remarks:        ****************************
+remarks:        * THIS OBJECT IS MODIFIED
+remarks:        * Please note that all data that is generally regarded as personal
+remarks:        * data has been removed from this object.
+remarks:        * To view the original object, please query the RIPE Database at:
+remarks:        * http://www.ripe.net/whois
+remarks:        ****************************
+

--- a/tests/data/irr_ripe.txt
+++ b/tests/data/irr_ripe.txt
@@ -7,13 +7,6 @@ mnt-by:         COLT-UK
 created:        2002-05-21T15:33:55Z
 last-modified:  2024-07-30T07:55:18Z
 source:         RIPE
-remarks:        ****************************
-remarks:        * THIS OBJECT IS MODIFIED
-remarks:        * Please note that all data that is generally regarded as personal
-remarks:        * data has been removed from this object.
-remarks:        * To view the original object, please query the RIPE Database at:
-remarks:        * http://www.ripe.net/whois
-remarks:        ****************************
 
 route:          212.166.64.0/19
 descr:          Tiscali Spain
@@ -24,13 +17,6 @@ notify:         david.barbarin@ibercom.com
 created:        2002-02-22T11:45:51Z
 last-modified:  2015-11-03T09:29:04Z
 source:         RIPE
-remarks:        ****************************
-remarks:        * THIS OBJECT IS MODIFIED
-remarks:        * Please note that all data that is generally regarded as personal
-remarks:        * data has been removed from this object.
-remarks:        * To view the original object, please query the RIPE Database at:
-remarks:        * http://www.ripe.net/whois
-remarks:        ****************************
 
 route:          212.80.191.0/24
 descr:          Cable&Wireless EUROPE
@@ -42,11 +28,15 @@ mnt-by:         EVOLUTIOCLOUD-MNT
 created:        1970-01-01T00:00:00Z
 last-modified:  2023-06-05T20:59:06Z
 source:         RIPE
-remarks:        ****************************
-remarks:        * THIS OBJECT IS MODIFIED
-remarks:        * Please note that all data that is generally regarded as personal
-remarks:        * data has been removed from this object.
-remarks:        * To view the original object, please query the RIPE Database at:
-remarks:        * http://www.ripe.net/whois
-remarks:        ****************************
+
+route:          212.80.191.0/24
+descr:          Cable&Wireless EUROPE
+descr:          assigned internal use
+origin:         AS12542
+notify:         ipadmin@cweurope.net
+notify:         aaron.hamilton@cweurope.net
+mnt-by:         EVOLUTIOCLOUD-MNT
+created:        1970-01-01T00:00:00Z
+last-modified:  2023-06-05T20:59:06Z
+source:         RIPE
 

--- a/tests/test_irr_parse.py
+++ b/tests/test_irr_parse.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from kartograf.irr.parse import parse_irr
+from .context import create_test_context
+
+
+def build_test_context(tmp_path):
+    epoch = "111111112"
+    context = create_test_context(tmp_path, epoch)
+    return context
+
+
+def test_parse_basic(tmp_path):
+    context = build_test_context(tmp_path)
+    parse_irr(context)
+    result_file = Path(context.out_dir_irr) / "irr_final.txt"
+    assert result_file.exists()
+
+    content = []
+    with open(str(result_file), 'r') as f:
+        for l in f.readlines():
+            content.append(l.strip())
+    assert content == ["193.254.30.0/24 AS12726", "212.166.64.0/19 AS12321", "212.80.191.0/24 AS12541"]

--- a/tests/test_irr_parse.py
+++ b/tests/test_irr_parse.py
@@ -21,3 +21,5 @@ def test_parse_basic(tmp_path):
         for l in f.readlines():
             content.append(l.strip())
     assert content == ["193.254.30.0/24 AS12726", "212.166.64.0/19 AS12321", "212.80.191.0/24 AS12541"]
+    # removed duplicate network with higher ASN
+    assert "212.80.191.0/24 AS12542" not in content

--- a/tests/test_irr_parse.py
+++ b/tests/test_irr_parse.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 
 from kartograf.irr.parse import parse_irr
-from .context import create_test_context
+from .context import create_test_context, setup_test_data
 
 
 def build_test_context(tmp_path):
     epoch = "111111112"
     context = create_test_context(tmp_path, epoch)
+    setup_test_data(context)
     return context
 
 

--- a/tests/test_rpki_parser.py
+++ b/tests/test_rpki_parser.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from kartograf.rpki.parse import parse_rpki
-from .context import create_test_context
+from .context import create_test_context, setup_test_data
 from .util.helpers import flatten
 
 
@@ -24,6 +24,7 @@ def test_roa_validations(tmp_path, capsys):
     '''
     epoch = "111111111"
     context = create_test_context(tmp_path, epoch)
+    setup_test_data(context)
     parse_rpki(context)
 
     # Check that rpki_final.txt was created

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
+import pytest
 from kartograf.util import parse_pfx, is_valid_pfx, get_root_network, rir_from_str
 
-import pytest
 
 def test_valid_ipv4_network():
     pfx = "192.144.11.0/24"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,6 @@
-from kartograf.util import parse_pfx, is_valid_pfx, get_root_network
+from kartograf.util import parse_pfx, is_valid_pfx, get_root_network, rir_from_str
+
+import pytest
 
 def test_valid_ipv4_network():
     pfx = "192.144.11.0/24"
@@ -64,3 +66,13 @@ def test_get_root_network():
     assert get_root_network(ipv6) == int("2001", 16)
     invalid = "not.a.network"
     assert get_root_network(invalid) is None
+
+
+def test_rir_from_string():
+    assert rir_from_str("ripe.db.route") == "RIPE"
+    assert rir_from_str("ARIN-file") == "ARIN"
+    assert rir_from_str("lacnic.db") == "LACNIC"
+    assert rir_from_str("afrinic-data") == "AFRINIC"
+    assert rir_from_str("apnic.db") == "APNIC"
+    with pytest.raises(Exception):
+        rir_from_str("invalid")


### PR DESCRIPTION
Initial PR for IRR parsing tests. Mostly setup, keeping the PR small.

Adds an IRR file to use as fixtures, and updates the test context to use them.
Adds a basic parsing test. 

branched off of #49 in order to use the test context, so this should go after.