### PR TITLE
bugfix: handle reproduce directory paths correctly

### DIFF
--- a/kartograf/context.py
+++ b/kartograf/context.py
@@ -20,12 +20,9 @@ class Context:
 
         self.reproduce = self.args.reproduce is not None
         if self.reproduce:
-            items = Path.iterdir(Path(self.args.reproduce))
-            source_folders = []
-            for folder in items:
-                full_path = self.args.reproduce / folder
-                if Path.is_dir(full_path):
-                    source_folders.append(folder.name)
+            data_path = Path(self.args.reproduce)
+            # in the data path, get the names of directories in the given path
+            source_folders = [ p.name for p in data_path.glob('*') if Path.is_dir(p) ]
             # We override the args because we are reproducing and only where we
             # have data we try to use is, the actual args passed don't matter.
             self.args.irr = 'irr' in source_folders

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -38,7 +38,9 @@ def test_map_context_with_reproduce(parser, tmp_path):
     assert context.epoch == '1225411200'
     assert context.epoch_dir == 'r1225411200'
     assert context.args.irr is True  # Should be True since irr dir exists
+    assert Path(context.data_dir_irr).exists()
     assert context.args.routeviews is True  # Should be True since collectors dir exists
+    assert Path(context.data_dir_collectors).exists()
 
 def test_map_context_with_wait(parser, tmp_path):
     args = parser.parse_args(['map', '-w', '1225411200'])


### PR DESCRIPTION
The 'full_path' variable in the reproduce step is incorrect, creating non-existent paths. The test passes because the path construction in kartograf.context checks that the name of the directory is valid but doesn't check that the path was constructed correctly. So the test passes, but the reproduce command fails.
This commit updates the path construction logic and adds an assertion that the path in the context exists.