### PR TITLE
Improve rpki validation

### DIFF
--- a/kartograf/context.py
+++ b/kartograf/context.py
@@ -20,12 +20,9 @@ class Context:
 
         self.reproduce = self.args.reproduce is not None
         if self.reproduce:
-            items = Path.iterdir(Path(self.args.reproduce))
-            source_folders = []
-            for folder in items:
-                full_path = self.args.reproduce / folder
-                if Path.is_dir(full_path):
-                    source_folders.append(folder.name)
+            data_path = Path(self.args.reproduce)
+            # in the data path, get the names of directories in the given path
+            source_folders = [ p.name for p in data_path.glob('*') if Path.is_dir(p) ]
             # We override the args because we are reproducing and only where we
             # have data we try to use is, the actual args passed don't matter.
             self.args.irr = 'irr' in source_folders

--- a/kartograf/context.py
+++ b/kartograf/context.py
@@ -35,9 +35,11 @@ class Context:
         if self.reproduce:
             if not self.args.reproduce.endswith('/'):
                 self.args.reproduce += '/'
-            self.data_dir = self.args.reproduce
+            abs_path = Path(self.args.reproduce).absolute()
+            self.data_dir = str(abs_path)
         else:
-            self.data_dir = str(cwd / "data" / self.epoch_dir)
+            abs_path = (Path("data") / self.epoch_dir).absolute()
+            self.data_dir = str(abs_path)
 
         if Path(self.data_dir).exists() and not self.reproduce:
             print("Not so fast, a folder with that epoch already exists.")

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -64,7 +64,7 @@ def parse_rpki(context):
                 if not prefix or is_bogon_pfx(prefix) or is_bogon_asn(asn):
                     if context.debug_log:
                         with open(context.debug_log, 'a') as logs:
-                            logs.write(f"RPKI: parser encountered an invalid IP network: {prefix}")
+                            logs.write(f"RPKI: parser encountered an invalid IP network: {prefix} \n")
                     continue
 
                 if context.max_encode and is_out_of_encoding_range(asn, context.max_encode):

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -64,7 +64,7 @@ def parse_rpki(context):
                 if not prefix or is_bogon_pfx(prefix) or is_bogon_asn(asn):
                     if context.debug_log:
                         with open(context.debug_log, 'a') as logs:
-                            logs.write(f"RPKI: parser encountered an invalid IP network: {prefix} \n")
+                            logs.write(f"RPKI: parser encountered an invalid IP network: {prefix}\n")
                     continue
 
                 if context.max_encode and is_out_of_encoding_range(asn, context.max_encode):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -56,6 +56,8 @@ def test_directory_creation(parser, tmp_path):
     os.chdir(tmp_path)
     context = Context(args)
 
+    assert Path(context.data_dir).is_absolute()
+
     rpki_cache = context.data_dir_rpki_cache
     assert isinstance(rpki_cache, str)
     assert Path(rpki_cache).exists()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -38,7 +38,9 @@ def test_map_context_with_reproduce(parser, tmp_path):
     assert context.epoch == '1225411200'
     assert context.epoch_dir == 'r1225411200'
     assert context.args.irr is True  # Should be True since irr dir exists
+    assert Path(context.data_dir_irr).exists()
     assert context.args.routeviews is True  # Should be True since collectors dir exists
+    assert Path(context.data_dir_collectors).exists()
 
 def test_map_context_with_wait(parser, tmp_path):
     args = parser.parse_args(['map', '-w', '1225411200'])


### PR DESCRIPTION
TLDR: by passing multiple ROA files to the `-f` files, it's about 2x faster. ~This PR removes parallelization via `ThreadPoolExecutor()` which may result in even more gains.~

Putting this up for concept ACK (@fjahr), while the impl works and reproduces existing validation, need to run more sanity checks as the output of `rpki_raw.json` is fairly different.

#### Impl
The rpki-client '-f' flag can handle multiple ROA files [1](https://github.com/rpki-client/rpki-client-openbsd/blob/4c5bb63322a87437b4670b1f49e4c1b382772a8e/src/usr.sbin/rpki-client/main.c#L1272). Instead of passing files one by one, which means invoking the rpki-client via a subprocess call, we pass them in batches of 250. 
This means we get back a binary blob of concatenated JSON, without delimiters. We match on the separator between items `b"\n}\n{\n\t"` (which is unique to defining the end of one item and the beginning of another), and insert a JSON-valid separator. 
Since now we just have JSON, we can write to a JSON file for each batch without building up results in memory.
~I removed the parallelism via `ThreadPoolExecutor` since it seemed to be mostly a feature to speed up the previous implementation. I couldn't get it to work with the new setup but didn't look too hard, it may be worth exploring to get some more performance improvements. On my machine, this implementation is a little more than 2x faster than the current.~ On my machine, the non-parallelized version is about 2x faster, and the parallelized version another 7 or 8x faster. 

#### Testing
I noticed some significant differences in the intermediate `rpki_raw.json` file, but these didn't seem to impact the `rpki_final.txt` file. i.e. the RPKI validation results in the same output. Notably, this approach seems to reduce duplicates in the `rpki_raw.json`.
To test, you want to have an existing run with the old version (or run one yourself), and then run a reproduction run with this branch. ~I got different hashes for the `rpki_final.txt` but the content was identical. I'm not sure why this is, and I'm still checking through this.~ I ran runs and got the same `rpki_final.txt` hashes across different reproductions runs. I did get different `final_result.txt` hashes but I don't think it's related to this change (to be confirmed). 

This is rebased on #61 (bugfix). 