### PR TITLE
tests: add IRR validation & tiebreakers tests, use comprehension

### DIFF
--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -79,7 +79,7 @@ def parse_irr(context):
                     if context.max_encode and is_out_of_encoding_range(origin, context.max_encode):
                         continue
 
-                    # There are dublicates and multiple entries for some
+                    # There are duplicates and multiple entries for some
                     # prefixes in the IRR DBs, so we need to deal with them
                     # here.
                     if output_cache.get(route):

--- a/tests/data/irr_ripe.txt
+++ b/tests/data/irr_ripe.txt
@@ -29,14 +29,56 @@ created:        1970-01-01T00:00:00Z
 last-modified:  2023-06-05T20:59:06Z
 source:         RIPE
 
-route:          212.80.191.0/24
-descr:          Cable&Wireless EUROPE
-descr:          assigned internal use
-origin:         AS12542
-notify:         ipadmin@cweurope.net
-notify:         aaron.hamilton@cweurope.net
-mnt-by:         EVOLUTIOCLOUD-MNT
-created:        1970-01-01T00:00:00Z
-last-modified:  2023-06-05T20:59:06Z
+route:          212.16.0.0/24
+descr:          Test Network 1
+origin:         AS12345
+mnt-by:         TEST-MNT
+created:        2023-01-01T00:00:00Z
+last-modified:  2023-01-01T00:00:00Z
+source:         RIPE
+
+route:          212.16.0.0/24
+descr:          Test Network 1 Duplicate
+origin:         AS12346
+mnt-by:         TEST-MNT
+created:        2023-01-01T00:00:00Z
+last-modified:  2023-01-02T00:00:00Z
+source:         RIPE
+
+route:          212.17.0.0/24
+descr:          Test Network 2 - Same timestamp lower ASN
+origin:         AS12347
+mnt-by:         TEST-MNT
+created:        2023-01-01T00:00:00Z
+last-modified:  2023-01-01T00:00:00Z
+source:         RIPE
+
+route:          212.17.0.0/24
+descr:          Test Network 2 - Same timestamp higher ASN
+origin:         AS12348
+mnt-by:         TEST-MNT
+created:        2023-01-01T00:00:00Z
+last-modified:  2023-01-01T00:00:00Z
+source:         RIPE
+
+route6:         2345:2ca::/32
+descr:          Test IPv6 Network
+origin:         AS12345
+mnt-by:         TEST-MNT
+created:        2023-01-01T00:00:00Z
+last-modified:  2023-01-01T00:00:00Z
+source:         RIPE
+
+route:          212.18.0.0/24
+descr:          Test Network Wrong Source
+origin:         AS12345
+mnt-by:         TEST-MNT
+created:        2023-01-01T00:00:00Z
+last-modified:  2023-01-01T00:00:00Z
+source:         ARIN
+
+route:          212.19.0.0/24
+descr:          Test Incomplete Entry
+origin:         AS12345
 source:         RIPE
 

--- a/tests/test_irr_parse.py
+++ b/tests/test_irr_parse.py
@@ -11,37 +11,22 @@ def build_test_context(tmp_path):
     return context
 
 
-def test_parse_basic(tmp_path):
-    context = build_test_context(tmp_path)
-    parse_irr(context)
-    result_file = Path(context.out_dir_irr) / "irr_final.txt"
-    assert result_file.exists()
-
-    with open(str(result_file), 'r') as f:
-        content = [ l.strip() for l in f.readlines() ]
-    assert content == ["193.254.30.0/24 AS12726", "212.166.64.0/19 AS12321", "212.80.191.0/24 AS12541", "212.16.0.0/24 AS12346", "212.17.0.0/24 AS12347", "2345:2ca::/32 AS12345" ]
-
-
 def test_parse_validation_cases(tmp_path):
     """
-    Test various IRR parsing validation cases:
-    - Timestamp based conflict resolution
-    - ASN based conflict resolution
-    - IPv6 handling
-    - Wrong source filtering
-    - Incomplete entry filtering
+    Test various IRR parsing validation cases.
     """
     context = build_test_context(tmp_path)
     parse_irr(context)
 
     result_file = Path(context.out_dir_irr) / "irr_final.txt"
-    assert result_file.exists()
 
     with open(str(result_file), 'r') as f:
         content = [l.strip() for l in f.readlines()]
 
+    assert result_file.exists()
+
     # Test duplicate network, newer timestamp wins
-    assert "212.16.0.0/24 AS12346" in content  #
+    assert "212.16.0.0/24 AS12346" in content
     assert "212.16.0.0/24 AS12345" not in content
 
     # Test same timestamp resolution, lower ASN wins
@@ -56,3 +41,6 @@ def test_parse_validation_cases(tmp_path):
 
     # Test incomplete entry
     assert "212.19.0.0/24 AS12345" not in content
+
+    # Test expected set
+    assert content == ["193.254.30.0/24 AS12726", "212.166.64.0/19 AS12321", "212.80.191.0/24 AS12541", "212.16.0.0/24 AS12346", "212.17.0.0/24 AS12347", "2345:2ca::/32 AS12345" ]


### PR DESCRIPTION
Adds tests for IRR validations and tiebreakers. 
Removes the duplicate test and corresponding fixture from the `test_parse_basic` test.
Use a list comprehension instead of the more verbose form in the  `test_parse_basic` test.
Small spelling fix.