### PR TITLE
test: add check for invalid "--wait" arg

### DIFF
--- a/kartograf/cli.py
+++ b/kartograf/cli.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import sys
+import time
 import kartograf
 from kartograf.kartograf import Kartograf
 
@@ -89,6 +90,9 @@ def main(args=None):
 
         if args.wait and args.reproduce:
             parser.error("--reproduce is not compatible with --wait.")
+
+        if args.wait and (int(args.wait) < time.time()):
+            parser.error(f"Cannot wait for a timestamp in the past ({args.wait})")
 
     if args.command == "map":
         Kartograf.map(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,13 @@ def test_map_with_options(parser):
     assert args.reproduce == '/path'
     assert args.epoch == '123'
 
+def test_map_with_past_wait(capsys):
+    args = ['map', '-w', '1225411200']
+    with pytest.raises(SystemExit):
+        main(args)
+    captured = capsys.readouterr()
+    assert captured.err.startswith("usage:")
+
 def test_merge_command(parser):
     args = parser.parse_args(['merge'])
     assert args.command == 'merge'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,7 @@ def test_map_with_past_wait(capsys):
     with pytest.raises(SystemExit):
         main(args)
     captured = capsys.readouterr()
-    assert captured.err.startswith("usage:")
+    assert "Cannot wait for a timestamp in the past (1225411200)" in captured.err
 
 def test_merge_command(parser):
     args = parser.parse_args(['merge'])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,13 +25,13 @@ def test_reproduce_args_failure(capsys):
     with pytest.raises(SystemExit):
         main(args)
     captured = capsys.readouterr()
-    assert captured.err.startswith("usage:")
+    assert "--epoch is required when --reproduce is set." in captured.err
 
     args = ['map', '-t', '123456789']
     with pytest.raises(SystemExit):
         main(args)
     captured = capsys.readouterr()
-    assert captured.err.startswith("usage:")
+    assert "--reproduce is required when --epoch is set." in captured.err
 
 def test_map_with_options(parser):
     args = parser.parse_args(['map', '-c', '-irr', '-rv', '-r', '/path', '-t', '123'])
@@ -73,7 +73,7 @@ def test_invalid_command(parser, capsys):
     with pytest.raises(SystemExit):
         parser.parse_args(['invalid'])
     captured = capsys.readouterr()
-    assert captured.err.startswith("usage:")
+    assert "invalid choice: 'invalid' (choose from 'map', 'merge', 'cov')" in captured.err
 
 def test_version_flag(parser, capsys):
     with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
checks that the argument is not in the past.
This checks it at the CLI parsing level. Context tests have past timestamps for example, and this is correct since the context does not check the validity of the args.