### PR TITLE
Print data found by parser, Loosen IRR  parser rules

### DIFF
--- a/kartograf/collectors/parse.py
+++ b/kartograf/collectors/parse.py
@@ -13,6 +13,7 @@ from kartograf.util import parse_pfx
 def parse_routeviews_pfx2as(context):
     raw_file = Path(context.out_dir_collectors) / "pfx2asn.txt"
     clean_file = Path(context.out_dir_collectors) / "pfx2asn_clean.txt"
+    written_lines = 0
 
     print("Cleaning " + str(raw_file))
     with open(raw_file, 'r') as raw, open(clean_file, 'w') as clean:
@@ -38,6 +39,7 @@ def parse_routeviews_pfx2as(context):
                     continue
 
                 clean.write(f"{prefix} {asn}\n")
+                written_lines += 1
                 continue
 
             # If the line contains a mulit-origin route (signified by the _)
@@ -67,3 +69,6 @@ def parse_routeviews_pfx2as(context):
                 continue
 
             clean.write(f"{prefix} {asn}\n")
+            written_lines += 1
+
+    print("Entries after cleanup:", written_lines)

--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -34,6 +34,7 @@ def parse_irr(context):
 
         entry_list = []
         current_entry = {}
+        prev_count = len(output_cache)
 
         # Parse the RPSL objects in the IRR DB into Python Dicts
         for line in lines:
@@ -98,6 +99,8 @@ def parse_irr(context):
 
                     else:
                         output_cache[route] = [origin, last_modified]
+
+        print("Found in this file:", len(output_cache) - prev_count)
 
     print("Found valid, unique entries:", len(output_cache))
 

--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -47,7 +47,7 @@ def parse_irr(context):
                     current_entry[k.strip()] = v.strip()
 
         for entry in entry_list:
-            is_complete = all(k in entry for k in ("origin", "source", "last-modified"))
+            is_complete = all(k in entry for k in ("origin", "source"))
             has_route = any(k in entry for k in ("route", "route6"))
             if is_complete and has_route:
                 # Some RIRs mirror some other RIRs in their DBs, ignore the
@@ -65,7 +65,9 @@ def parse_irr(context):
 
                     route = parse_pfx(route)
 
-                    last_modified = datetime.strptime(entry["last-modified"], '%Y-%m-%dT%H:%M:%SZ')
+                    # AFRINIC and LACNIC appear to not use last modified anymore
+                    last_modified = entry.get("last-modified", "2009-01-03T19:15:05Z")
+                    last_modified = datetime.strptime(last_modified, '%Y-%m-%dT%H:%M:%SZ')
                     last_modified = last_modified.replace(tzinfo=timezone.utc)
                     last_modified = last_modified.timestamp()
 

--- a/tests/data/irr_ripe.txt
+++ b/tests/data/irr_ripe.txt
@@ -80,5 +80,4 @@ source:         ARIN
 route:          212.19.0.0/24
 descr:          Test Incomplete Entry
 origin:         AS12345
-source:         RIPE
 

--- a/tests/test_irr_parse.py
+++ b/tests/test_irr_parse.py
@@ -39,7 +39,7 @@ def test_parse_validation_cases(tmp_path):
     # Test wrong source exclusion: ARIN in RIPE file
     assert "212.18.0.0/24 AS12345" not in content
 
-    # Test incomplete entry
+    # Test incomplete entry (no source in data)
     assert "212.19.0.0/24 AS12345" not in content
 
     # Test expected set


### PR DESCRIPTION
Unfortunately it seems like our IRR parser has been too strict and we did not use Afrinic and Lacnic data because they stopped using the `last-modified` field. I noticed some weird behavior when working on https://github.com/asmap/sample-data/pull/1 and just investigated it now.

We did not notice this from looking at the logs because we were only printing the total entries found in all IRR files and this number looked ok because we were still using the largest three RIRs.

Fix this (1) doing per file logging in IRR and also log numbers in parser of collectors (2) make irr parser more permissive if `last-modified` is missing.