### PR TITLE
rpki: Rely on rpki-client management of TALs again

### DIFF
--- a/kartograf/context.py
+++ b/kartograf/context.py
@@ -47,7 +47,6 @@ class Context:
 
         self.data_dir_irr = str(Path(self.data_dir) / "irr")
         self.data_dir_rpki_cache = str(Path(self.data_dir) / "rpki" / "cache")
-        self.data_dir_rpki_tals = str(Path(self.data_dir) / "rpki" / "tals")
         self.data_dir_collectors = str(Path(self.data_dir) / "collectors")
         # Out dir
         self.out_dir = str(cwd / "out" / self.epoch_dir)
@@ -58,7 +57,6 @@ class Context:
         # We skip creating the folders if we are reproducing a run.
         if not self.reproduce:
             Path(self.data_dir_rpki_cache).mkdir(parents=True)
-            Path(self.data_dir_rpki_tals).mkdir(parents=True)
             if self.args.irr:
                 Path(self.data_dir_irr).mkdir(parents=True)
             if self.args.routeviews:

--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -1,11 +1,9 @@
 import subprocess
-import sys
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
 from threading import Lock
 from pathlib import Path
-import requests
 from tqdm import tqdm
 
 from kartograf.timed import timed
@@ -14,50 +12,9 @@ from kartograf.util import (
     calculate_sha256_directory,
 )
 
-TAL_URLS = {
-    "afrinic": "http://rpki.afrinic.net/tal/afrinic.tal",
-    "apnic": "https://tal.apnic.net/tal-archive/apnic-rfc7730-https.tal",
-    "arin": "https://www.arin.net/resources/manage/rpki/arin.tal",
-    "lacnic": "https://www.lacnic.net/rpki/lacnic.tal",
-    "ripe": "https://tal.rpki.ripe.net/ripe-ncc.tal"
-}
-
-
-def download_rir_tals(context):
-    tals = []
-
-    for rir, url in TAL_URLS.items():
-        try:
-            response = requests.get(url, timeout=600)
-            response.raise_for_status()
-
-            tal_path = Path(context.data_dir_rpki_tals) / f"{rir}.tal"
-            with open(tal_path, 'wb') as file:
-                file.write(response.content)
-
-            print(f"Downloaded TAL for {rir.upper()} to {tal_path}, file hash: {calculate_sha256(tal_path)}")
-            tals.append(tal_path)
-
-        except requests.RequestException as e:
-            print(f"Error downloading TAL for {rir.upper()}: {e}")
-            sys.exit(1)
-
-
-def data_tals(context):
-    tal_paths = list(Path(context.data_dir_rpki_tals).rglob('*.tal'))
-    # We need to have 5 TALs, one from each RIR
-    if len(tal_paths) == 5:
-        return tal_paths
-
-    print("Not all 5 TALs could be downloaded.")
-    sys.exit(1)
-
 
 @timed
 def fetch_rpki_db(context):
-    # Download TALs and presist them in the RPKI data folder
-    download_rir_tals(context)
-    tal_options = [item for path in data_tals(context) for item in ('-t', path)]
     print("Downloading RPKI Data, this may take a while.")
     if context.debug_log:
         with open(context.debug_log, 'a') as logs:
@@ -65,14 +22,14 @@ def fetch_rpki_db(context):
             logs.flush()  # Without this the line above is not appearing first in the logs
             subprocess.run(["rpki-client",
                             "-d", context.data_dir_rpki_cache
-                            ] + tal_options,
+                            ],
                            stdout=logs,
                            stderr=logs,
                            check=False)
     else:
         subprocess.run(["rpki-client",
                         "-d", context.data_dir_rpki_cache
-                        ] + tal_options,
+                        ],
                        capture_output=True,
                        check=False)
 
@@ -90,8 +47,6 @@ def validate_rpki_db(context):
     rpki_raw_file = 'rpki_raw.json'
     result_path = Path(context.out_dir_rpki) / rpki_raw_file
 
-    tal_options = [item for path in data_tals(context) for item in ('-t', path)]
-
     debug_file_lock = Lock()
 
     if context.debug_log:
@@ -106,7 +61,7 @@ def validate_rpki_db(context):
                                  context.data_dir_rpki_cache,
                                  "-P",
                                  context.epoch,
-                                 ] + tal_options +
+                                 ] +
                                  ["-f"] + batch,  # -f has to be last
                                  capture_output=True,
                                  check=False)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -63,11 +63,6 @@ def test_directory_creation(parser, tmp_path):
     assert Path(rpki_cache).exists()
     assert Path(rpki_cache).parent.name == "rpki"
 
-    rpki_tals = context.data_dir_rpki_tals
-    assert isinstance(rpki_tals, str)
-    assert Path(rpki_tals).exists()
-    assert Path(rpki_tals).parent.name == "rpki"
-
     data_dir_irr = context.data_dir_irr
     assert isinstance(data_dir_irr, str)
     assert Path(data_dir_irr).exists()


### PR DESCRIPTION
This change depends on the upcoming `rpki-client` release (9.5) which isn't out yet, that's why it is in draft. Not sure when it would be a good time to merge, we already ask people to use the latest `rpki-client` but 9.5 would need to be widely available at least and this is also not critical so we can probably wait with this for a while.

We are currently managing the TALs ourselves, download them and give them to `rpki-client` as options. We had to do this because `rpki-client` didn't include the ARIN TAL in their releases for a while because of some licensing concerns: https://github.com/rpki-client/rpki-client-portable/issues/80 However, in January ARIN revised the license and so now all TALs will be included in the releases again: https://github.com/rpki-client/rpki-client-portable/commit/05de5a20a69f30a7d99ee2bd24d2512f28dc158f

That means we can remove a bunch of code, when we feel ready for it.