### PR TITLE
ci: Don't run pylint twice

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,6 +1,10 @@
 name: Pylint Check
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   lint:


### PR DESCRIPTION
Somehow the current config means the pylint ci gets run twice (see for example #70), so change that by using the same style as in the other ci jobs.