### PR TITLE
Upgrade to rpki-client 9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ to enable flakes in your Nix config, then run `nix develop`.
 
 #### rpki-client
 
-Kartograf requires `rpki-client` version 8.4 or higher to be installed locally. Many package managers have `rpki-client`, however please note that typically only the latest version is available. Kartograf is currently tested to work with `rpki-client` 8.4 - 9.4. If a new release is available that breaks compatibility, you may need to build a compatible `rpki-client` version yourself if your preferred package manager does not have a compatible version available. In that case, see the [instructions in the rpki-client-portable project](https://github.com/rpki-client/rpki-client-portable/blob/master/INSTALL).
+Kartograf requires `rpki-client` version 8.4 or higher to be installed locally. Many package managers have `rpki-client`, however please note that typically only the latest version is available. Kartograf is currently tested to work with `rpki-client` 8.4 - 9.5. If a new release is available that breaks compatibility, you may need to build a compatible `rpki-client` version yourself if your preferred package manager does not have a compatible version available. In that case, see the [instructions in the rpki-client-portable project](https://github.com/rpki-client/rpki-client-portable/blob/master/INSTALL).
 
 ```
 # Linux/BSD

--- a/flake.lock
+++ b/flake.lock
@@ -33,50 +33,50 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1727388158,
-        "narHash": "sha256-WtNCxHZ7jtpZHEagvWMcyY4pHjFAHk9k/3Z0K3pJka8=",
-        "owner": "asmap",
-        "repo": "rpki-client-nix",
-        "rev": "b9b68b6d4b8170213c741362797ea13029913222",
-        "type": "github"
+        "lastModified": 1744625000,
+        "narHash": "sha256-/GB5ZN+Da5XWDnqmc0gJKEG2+8ZNHJQYZgxZx0lN+Jc=",
+        "ref": "refs/heads/upgrade-rpki-9.5",
+        "rev": "224beb9695c9e3629ad8d2de3b0e3b97c04fbc15",
+        "revCount": 33,
+        "type": "git",
+        "url": "file:///home/base/code/asmap/rpki-client-nix"
       },
       "original": {
-        "owner": "asmap",
-        "repo": "rpki-client-nix",
-        "type": "github"
+        "type": "git",
+        "url": "file:///home/base/code/asmap/rpki-client-nix"
       }
     },
     "rpki-client-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1736205605,
-        "narHash": "sha256-2/xe6BBZYo0IDYDFbPEdbCvYTdzQEb1Zl0BBQf/Z0aA=",
+        "lastModified": 1744153109,
+        "narHash": "sha256-BYfJwSVm+w7AZu34HD0XY5ORkxYNEtYDK6cn8h8WrQY=",
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "98954f463a60c1aa1f9c0c0de83370558ba452c7",
+        "rev": "36abf5dbc510ef98e5139f776806b723d3bcc705",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "98954f463a60c1aa1f9c0c0de83370558ba452c7",
+        "rev": "36abf5dbc510ef98e5139f776806b723d3bcc705",
         "type": "github"
       }
     },
     "rpki-openbsd-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1735901016,
-        "narHash": "sha256-+KexblAyPNHWwAGAdOzfWjZKXuwSqp12FrXFHuyFQnE=",
+        "lastModified": 1744104505,
+        "narHash": "sha256-OUfBK+mwOZ4KkvAWKFfrHU/c0iv2hmFisLOBg+Tfu34=",
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "27f8f58679530181c9e2f546046b714ad6f85b8c",
+        "rev": "f89bbe32af942a4dac8d2f9c13058ff63afa11d3",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "27f8f58679530181c9e2f546046b714ad6f85b8c",
+        "rev": "f89bbe32af942a4dac8d2f9c13058ff63afa11d3",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
     utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
 
-      rpki-client = rpki-cli.defaultPackage.${system};
+      rpki-client = rpki-cli.packages.${system}.default;
       pythonBuildDeps = pkgs.python311.withPackages (ps: [
         ps.beautifulsoup4
         ps.pandas
@@ -72,7 +72,7 @@
             wrapProgram $out/bin/kartograf \
               --set PYTHONPATH $out/lib:$PYTHONPATH
             wrapProgram $out/bin/kartograf \
-              --set PATH ${rpki-cli.defaultPackage.${system}}/bin:$PATH
+              --set PATH ${rpki-client}/bin:$PATH
           '';
           meta = with pkgs.lib; {
             description = "Kartograf: IP to ASN mapping for everyone";

--- a/kartograf/util.py
+++ b/kartograf/util.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 import time
 
-RPKI_VERSION = 9.4
+RPKI_VERSION = 9.5
 
 
 def calculate_sha256(file_path):


### PR DESCRIPTION
Upgrades via [rpki-client-nix](https://github.com/asmap/rpki-client-nix). Depends on [#15](https://github.com/asmap/rpki-client-nix/pull/15) in that repo.

Also updates the default package attribute accordingly.

Tested by entering the dev env and running `./run map`, which completed successfully.
