### PR TITLE
remove intermediate routeviews files after merge

### DIFF
--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import ipaddress
 import shutil
+import os
 import pandas as pd
 
 from kartograf.timed import timed
@@ -98,6 +99,8 @@ def merge_pfx2as(context):
         out_file
     )
     shutil.copy2(out_file, context.final_result_file)
+    os.remove(rv_file)
+    os.remove(rv_filtered_file)
 
 
 def extra_file_to_df(extra_file_path):


### PR DESCRIPTION
Kartograf generates intermediate files after extracting raw data. These are not useful to the user and take up a space, so we should clean them up.

For Routeviews specifically, the `out/_timestamp` directory ends up with five files:
- `pfx2asn.txt`
- `pfx2asn_clean.txt`
- `pfx2asn_filtered.txt`
- `routeviews_pfx2asn_ip4.txt`
- `routeviews_pfx2asn_ip6.txt`

Arguably, only the  `pfx2asn_filtered.txt` is a true "output" file, as it is the routeviews data which was not found in RPKI or IRR files. This data gets merged into the final output for the run anyway. All these files can be removed and recreated from the corresponding `data/` folder. 

Here, we remove the `_clean.txt` and `_filtered.txt` file after they're processed and merged into other files. This should save about 40M from disk.