### PR TITLE
test_cli: remove single-quoted cli arguments

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,7 +83,7 @@ def test_invalid_command(parser, capsys):
     with pytest.raises(SystemExit):
         parser.parse_args(['invalid'])
     captured = capsys.readouterr()
-    assert "invalid choice: 'invalid' (choose from 'map', 'merge', 'cov')" in captured.err
+    assert "invalid choice: 'invalid'" in captured.err
 
 def test_version_flag(parser, capsys):
     with pytest.raises(SystemExit) as excinfo:


### PR DESCRIPTION
bug reported [here](https://github.com/asmap/kartograf/issues/88)
see https://github.com/python/cpython/pull/130751
this is a bug in cpython. The argument parsing behavior was changed in between two minor releases of Python 12. In order to continue working across Python versions, we relax the error message check.

Note that I was unable to reproduce this via Nixpkgs Python versions 3.11-3.13. Please test with Python downloaded from PIP. 