### PR TITLE
Print logs cleanup

### DIFF
--- a/kartograf/collectors/parse.py
+++ b/kartograf/collectors/parse.py
@@ -60,7 +60,9 @@ def parse_routeviews_pfx2as(context):
             prefix = parse_pfx(prefix)
             asn = asn.upper().rstrip('\n')
 
-            if not prefix or is_bogon_pfx(prefix) or is_bogon_asn(asn):
+            if not prefix:
+                continue
+            if is_bogon_pfx(prefix) or is_bogon_asn(asn):
                 if context.debug_log:
                     with open(context.debug_log, 'a') as logs:
                         logs.write(f"Routeviews: parser encountered an invalid IP network: {prefix}")

--- a/kartograf/collectors/parse.py
+++ b/kartograf/collectors/parse.py
@@ -16,7 +16,6 @@ def parse_routeviews_pfx2as(context):
     context.cleanup_out_files.append(raw_file)
     written_lines = 0
 
-    print("Cleaning " + str(raw_file))
     with open(raw_file, 'r') as raw, open(clean_file, 'w') as clean:
         lines = raw.readlines()
         for line in lines:

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -71,12 +71,11 @@ def extract(file, context):
     gz_file = Path(context.data_dir_collectors) / (file + ".gz")
     file = Path(context.out_dir_collectors) / file
 
-    print(f'Unzipping {gz_file}')
+    print(f'Extracting {gz_file}')
     with gzip.open(gz_file, 'rb') as f_in:
         with open(file, 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)
 
-    print(f'Formatting {file}')
     with open(file, "r") as read:
         lines = read.readlines()
 
@@ -94,9 +93,9 @@ def fetch_routeviews_pfx2as(context):
     v6_file_gz = path / "routeviews_pfx2asn_ip6.txt.gz"
 
     download(latest_link(PFX2AS_V4), v4_file_gz)
-    print(f"Downloaded {v4_file_gz}, file hash: {calculate_sha256(v4_file_gz)}")
+    print(f"Downloaded {v4_file_gz.name}, file hash: {calculate_sha256(v4_file_gz)}")
     download(latest_link(PFX2AS_V6), v6_file_gz)
-    print(f"Downloaded {v6_file_gz}, file hash: {calculate_sha256(v6_file_gz)}")
+    print(f"Downloaded {v6_file_gz.name}, file hash: {calculate_sha256(v6_file_gz)}")
 
 
 def extract_routeviews_pfx2as(context):

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -71,7 +71,7 @@ def extract(file, context):
     gz_file = Path(context.data_dir_collectors) / (file + ".gz")
     file = Path(context.out_dir_collectors) / file
 
-    print(f'Extracting {gz_file}')
+    print(f'Extracting {gz_file.name}')
     with gzip.open(gz_file, 'rb') as f_in:
         with open(file, 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)

--- a/kartograf/irr/fetch.py
+++ b/kartograf/irr/fetch.py
@@ -41,7 +41,7 @@ def fetch_irr(context):
                 with open(local_file_path, 'wb') as f:
                     for chunk in response.iter_content(chunk_size=8192):
                         f.write(chunk)
-                print(f"Downloaded {file_name}, file hash: {calculate_sha256(local_file_path)}")
+                print(f"file hash: {calculate_sha256(local_file_path)}")
                 break
             except (requests.RequestException, ConnectionError) as e:
                 print(f"Connection issue while downloading {file_name}: {e}. Retrying... (Attempt {attempt + 1}/{max_retries})")
@@ -53,13 +53,13 @@ def fetch_irr(context):
 
 
 def extract_irr(context):
+    print("Extracting IRR DBs")
     for file in IRR_FILE_ADDRESSES:
         _, file_path = file.split("/", 1)
         _, file_name = file_path.rsplit("/", 1)
         local_file_path = Path(context.data_dir_irr) / file_name
         extracted_file_path = Path(context.out_dir_irr) / file_name.rstrip(".gz")
 
-        print("Extracting " + file_name)
         with gzip.open(local_file_path, 'rb') as r:
             with open(extracted_file_path, 'wb') as w:
                 shutil.copyfileobj(r, w)

--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -63,8 +63,11 @@ def parse_irr(context):
                     else:
                         continue
 
-                    route = parse_pfx(route)
-                    if not route:
+                    parsed_route = parse_pfx(route)
+                    if not parsed_route:
+                        if context.debug_log:
+                            with open(context.debug_log, 'a') as logs:
+                                logs.write(f"Could not parse prefix from line: {route}")
                         continue
 
                     # AFRINIC and LACNIC appear to not use last modified anymore
@@ -75,10 +78,10 @@ def parse_irr(context):
 
                     # Bogon prefixes and ASNs are excluded since they can not
                     # be used for routing.
-                    if is_bogon_pfx(route) or is_bogon_asn(origin):
+                    if is_bogon_pfx(parsed_route) or is_bogon_asn(origin):
                         if context.debug_log:
                             with open(context.debug_log, 'a') as logs:
-                                logs.write(f"IRR: parser encountered an invalid route: {route}\n")
+                                logs.write(f"IRR: parser encountered an invalid route: {parsed_route}\n")
                         continue
 
                     if context.max_encode and is_out_of_encoding_range(origin, context.max_encode):

--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -25,7 +25,6 @@ def parse_irr(context):
     output_cache: Dict[str, str] = {}
 
     for file in irr_files:
-        print(f"Parsing {file}")
         # We need to know the RIR of the file to check if it is equal to the
         # source later
         rir = rir_from_str(str(file))
@@ -105,7 +104,7 @@ def parse_irr(context):
                     else:
                         output_cache[route] = [origin, last_modified]
 
-        print("Found in this file:", len(output_cache) - prev_count)
+        print(f"Parsed {file.name}, found: {len(output_cache) - prev_count}")
 
     print("Found valid, unique entries:", len(output_cache))
 

--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -65,6 +65,8 @@ def parse_irr(context):
                         continue
 
                     route = parse_pfx(route)
+                    if not route:
+                        continue
 
                     # AFRINIC and LACNIC appear to not use last modified anymore
                     last_modified = entry.get("last-modified", "2009-01-03T19:15:05Z")
@@ -74,10 +76,10 @@ def parse_irr(context):
 
                     # Bogon prefixes and ASNs are excluded since they can not
                     # be used for routing.
-                    if not route or is_bogon_pfx(route) or is_bogon_asn(origin):
+                    if is_bogon_pfx(route) or is_bogon_asn(origin):
                         if context.debug_log:
                             with open(context.debug_log, 'a') as logs:
-                                logs.write(f"IRR: parser encountered an invalid route: {route}")
+                                logs.write(f"IRR: parser encountered an invalid route: {route}\n")
                         continue
 
                     if context.max_encode and is_out_of_encoding_range(origin, context.max_encode):

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -138,7 +138,7 @@ def general_merge(
     """
     Merge lists of IP networks into a base file.
     """
-    print("Parsing base file to dictionary")
+    print("Merging extra prefixes that were not included in the base file.")
     base = BaseNetworkIndex()
     with open(base_file, "r") as file:
         for line in file:
@@ -147,7 +147,6 @@ def general_merge(
 
     df_extra = extra_file_to_df(extra_file)
 
-    print("Merging extra prefixes that were not included in the base file.")
     extra_included = []
     for row in df_extra.itertuples(index=False):
         result = base.contains_row(row)
@@ -174,8 +173,6 @@ def general_merge(
 
     with open(base_file, "r") as base:
         base_contents = base.read()
-
-    print("Finished merging extra prefixes.")
 
     with open(out_file, "w") as merge_file:
         merge_file.write(base_contents + extra_contents)

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -138,14 +138,13 @@ def general_merge(
     """
     Merge lists of IP networks into a base file.
     """
-    print("Parse base file to dictionary")
+    print("Parsing base file to dictionary")
     base = BaseNetworkIndex()
     with open(base_file, "r") as file:
         for line in file:
             pfx, _ = line.split(" ")
             base.update(pfx)
 
-    print("Parse extra file to Pandas DataFrame")
     df_extra = extra_file_to_df(extra_file)
 
     print("Merging extra prefixes that were not included in the base file.")
@@ -157,13 +156,7 @@ def general_merge(
     df_extra["INCLUDED"] = extra_included
     df_filtered = df_extra[df_extra.INCLUDED == 0]
 
-    print("Finished merging extra prefixes.")
-
     if extra_filtered_file:
-        print(
-            f"Finished filtering! Originally {len(df_extra.index)} "
-            f"entries filtered down to {len(df_filtered.index)}"
-        )
         df_filtered.to_csv(
             extra_filtered_file,
             sep=" ",
@@ -175,17 +168,14 @@ def general_merge(
         with open(extra_filtered_file, "r") as extra:
             extra_contents = extra.read()
     else:
-        print(
-            f"Finished filtering! Originally {len(df_extra.index)} entries "
-            f"filtered down to {len(df_filtered.index)}"
-        )
         extra_contents = df_filtered.to_csv(
             None, sep=" ", index=False, columns=["PFXS", "ASNS"], header=False
         )
 
-    print("Merging base file with filtered extra file")
     with open(base_file, "r") as base:
         base_contents = base.read()
+
+    print("Finished merging extra prefixes.")
 
     with open(out_file, "w") as merge_file:
         merge_file.write(base_contents + extra_contents)

--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -50,7 +50,7 @@ def download_rir_tals(context):
             with open(tal_path, 'wb') as file:
                 file.write(response.content)
 
-            print(f"Downloaded TAL for {rir.upper()} to {tal_path}, file hash: {calculate_sha256(tal_path)}")
+            print(f"Downloaded TAL for {rir.upper()} to {tal_path.name}, file hash: {calculate_sha256(tal_path)}")
             tals.append(tal_path)
 
         except requests.RequestException as e:
@@ -157,4 +157,4 @@ def validate_rpki_db(context):
         with open(result_path, 'w') as f:
             json.dump(s, f)
 
-    print(f"{len(results_json)} RKPI ROAs validated\nSaved to: {result_path}\nFile hash: {calculate_sha256(result_path)}")
+    print(f"{len(results_json)} RKPI ROAs validated\nSaved to: {result_path.name}\nFile hash: {calculate_sha256(result_path)}")

--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -99,7 +99,6 @@ def fetch_rpki_db(context):
 
 @timed
 def validate_rpki_db(context):
-    print("Validating RPKI ROAs")
     files = [path for path in Path(context.data_dir_rpki_cache).rglob('*')
              if path.is_file() and ((path.suffix == ".roa")
                                     or (path.name == ".roa"))]
@@ -158,4 +157,4 @@ def validate_rpki_db(context):
         with open(result_path, 'w') as f:
             json.dump(s, f)
 
-    print(f"{len(results_json)} RKPI ROAs validated and saved to {result_path}, file hash: {calculate_sha256(result_path)}")
+    print(f"{len(results_json)} RKPI ROAs validated\nSaved to: {result_path}\nFile hash: {calculate_sha256(result_path)}")

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -59,6 +59,9 @@ def parse_rpki(context):
                 asn = vrp['asid']
                 prefix = parse_pfx(vrp['prefix'])
                 if not prefix:
+                    if context.debug_log:
+                        with open(context.debug_log, 'a') as logs:
+                            logs.write(f"Could not parse prefix from line: {vrp['prefix']}")
                     continue
                 # Bogon prefixes and ASNs are excluded since they can not
                 # be used for routing.

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -58,10 +58,11 @@ def parse_rpki(context):
             for vrp in roa['vrps']:
                 asn = vrp['asid']
                 prefix = parse_pfx(vrp['prefix'])
-
+                if not prefix:
+                    continue
                 # Bogon prefixes and ASNs are excluded since they can not
                 # be used for routing.
-                if not prefix or is_bogon_pfx(prefix) or is_bogon_asn(asn):
+                if is_bogon_pfx(prefix) or is_bogon_asn(asn):
                     if context.debug_log:
                         with open(context.debug_log, 'a') as logs:
                             logs.write(f"RPKI: parser encountered an invalid IP network: {prefix}\n")

--- a/pylintrc
+++ b/pylintrc
@@ -313,7 +313,7 @@ ignore-imports=yes
 ignore-signatures=yes
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=8
 
 
 [SPELLING]


### PR DESCRIPTION
We currently have some fairly verbose log printing, which was set up to be extra-helpful when getting the script functionality into place. With more stability, and the defaulting of `debug` to False, it's reasonable to revisit some of the printed logs. This also includes a small fix to logs in `debug.log`.

These changes remove, compact, or re-format some printed logs, and do not affect any input or output functionality.

The largest removal is the "extra filtered file" statements from the merge process. This is an internal process to the function so the log is both confusing and unnecessary. Also, we update the logs to the `debug.log` file to not print prefixes if they are not parsed as such. Currently, the behavior is to print `parser encountered an invalid IP network: None`.