### PR TITLE
Use trie in merge process

### DIFF
--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -1,15 +1,11 @@
-from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 import ipaddress
-import math
-import os
 import shutil
-from types import SimpleNamespace
 import pandas as pd
 
 from kartograf.timed import timed
+from kartograf.trie import IPTrie
 from kartograf.util import get_root_network
-
 
 class BaseNetworkIndex:
     '''
@@ -21,63 +17,33 @@ class BaseNetworkIndex:
     instead of all the networks in the base file.
     '''
 
-
     def __init__(self):
-        self._dict = {4: {}, 6: {}}
-        self._v4_keys = self._dict[4].keys()
-        self._v6_keys = self._dict[6].keys()
+        self._trie = IPTrie()
 
     def update(self, pfx):
         try:
-            ipn = ipaddress.ip_network(pfx)
+            ipn = ipaddress.ip_network(pfx, strict=False)
         except ValueError:
             print(f"Invalid prefix provided: {pfx}")
             return
-
-        netw = int(ipn.network_address)
-        mask = int(ipn.netmask)
-        v = ipn.version
-        root_net = get_root_network(pfx)
-
-        if (root_net in self._v4_keys) or (root_net in self._v6_keys):
-            current = self._dict[v][root_net]
-            self._dict[v][root_net] = current + [(netw, mask, ipn.prefixlen)]
-        else:
-            self._dict[v].update({root_net: [(netw, mask, ipn.prefixlen)]})
-
-    def check_inclusion(self, row, root_net, version):
-        """
-        A network is a subnet of another if the bitwise AND of its IP and the base network's netmask
-        is equal to the base network IP, and the network's prefix length is larger or equal than the base network's
-        prefix length.
-        """
-        candidate = ipaddress.ip_network(row.PFXS)
-        for net, mask, prefixlen in self._dict[version][root_net]:
-            if candidate.prefixlen >= prefixlen and row.INETS & mask == net:
-                return 1
-        return 0
+        self._trie.insert(pfx, ipn.prefixlen)
 
     def contains_row(self, row):
-        root_net = row.PFXS_LEADING
-        version = ipaddress.ip_network(row.PFXS).version
-        if version == 4 and (root_net in self._v4_keys):
-            return self.check_inclusion(row, root_net, version)
-        if version == 6 and (root_net in self._v6_keys):
-            return self.check_inclusion(row, root_net, version)
+        """
+        Check if the prefix in the row is covered by any prefix in the base file.
+        A candidate prefix is covered if:
+        1. Its network address matches a base prefix in the trie
+        2. The matching base prefix length <= candidate prefix length
+           (i.e., base prefix is equal or broader than candidate)
+        """
+        try:
+            candidate = ipaddress.ip_network(row.PFXS, strict=False)
+        except ValueError:
+            return 0
+        base_prefixlen = self._trie.lookup(candidate.network_address)
+        if base_prefixlen is not None and base_prefixlen <= candidate.prefixlen:
+            return 1
         return 0
-
-    def get_serializable_dict(self):
-        """Return the internal dict for serialization to worker processes."""
-        return self._dict
-
-    @classmethod
-    def from_dict(cls, data_dict):
-        """Reconstruct a BaseNetworkIndex from a serialized dict."""
-        instance = cls()
-        instance._dict = data_dict
-        instance._v4_keys = instance._dict[4].keys()
-        instance._v6_keys = instance._dict[6].keys()
-        return instance
 
 @timed
 def merge_irr(context):
@@ -149,34 +115,13 @@ def extra_file_to_df(extra_file_path):
 
     return df_extra
 
-def process_chunk_worker(chunk_data, base_dict):
-    base = BaseNetworkIndex.from_dict(base_dict)
-
-    results = []
-    for original_idx, (net_int, pfx, pfx_leading) in chunk_data:
-        row = SimpleNamespace(PFXS=pfx, PFXS_LEADING=pfx_leading, INETS=net_int)
-
-        result = base.contains_row(row)
-        results.append((original_idx, result))
-    return results
-
-
-def pick_chunk_size(n_rows: int, workers: int | None = None,
-                    min_chunk: int = 5,
-                    max_chunk: int = 200_000) -> int:
-    if workers is None:
-        workers = os.cpu_count() or 4
-    chunk = math.ceil(n_rows / workers)
-    return max(min_chunk, min(max_chunk, chunk))
-
-
 def general_merge(
     base_file, extra_file, extra_filtered_file, out_file
 ):
     """
     Merge lists of IP networks into a base file.
     """
-    print("Merging extra prefixes that were not included in the base file.")
+    print("Creating network index from base file.")
     base_network_index = BaseNetworkIndex()
     with open(base_file, "r") as file:
         for line in file:
@@ -185,28 +130,12 @@ def general_merge(
 
     df_extra = extra_file_to_df(extra_file)
 
-    len_df_extra = len(df_extra)
-    chunk_size = pick_chunk_size(len_df_extra)
-    chunks = []
-    chunk_data = []
-    for i, row in df_extra.iterrows():
-        chunk_data.append((i, (row.INETS, row.PFXS, row.PFXS_LEADING)))
-        if (i + 1) % chunk_size == 0 or i == len_df_extra - 1:
-            chunks.append(chunk_data)
-            chunk_data = []
+    print("Merging extra prefixes that were not included in the base file.")
+    extra_included = []
+    for row in df_extra.itertuples(index=False):
+        extra_included.append(base_network_index.contains_row(row))
 
-    all_results = []
-    with ProcessPoolExecutor() as executor:
-        base_dict = base_network_index.get_serializable_dict()
-        futures = [executor.submit(process_chunk_worker, chunk, base_dict) for chunk in chunks]
-
-        for future in futures:
-            all_results.extend(future.result())
-
-    # Sort by original index
-    all_results.sort(key=lambda x: x[0])
-
-    df_extra["INCLUDED"] = [result for _, result in all_results]
+    df_extra["INCLUDED"] = extra_included
 
     df_filtered = df_extra[df_extra.INCLUDED == 0]
 

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -31,8 +31,7 @@ class BaseNetworkIndex:
     def contains_row(self, row):
         """
         Check if the prefix in the row is covered by any prefix in the base file.
-        A candidate prefix is covered if:
-        Its network address matches a base prefix in the trie
+        A candidate prefix is covered if its network address matches a prefix in the trie
         """
         try:
             candidate = ipaddress.ip_network(row.PFXS, strict=False)

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -20,28 +20,26 @@ class BaseNetworkIndex:
     def __init__(self):
         self._trie = IPTrie()
 
-    def update(self, pfx):
+    def update(self, pfx, asn):
         try:
             ipn = ipaddress.ip_network(pfx, strict=False)
         except ValueError:
             print(f"Invalid prefix provided: {pfx}")
             return
-        self._trie.insert(pfx, ipn.prefixlen)
+        self._trie.insert(ipn, asn)
 
     def contains_row(self, row):
         """
         Check if the prefix in the row is covered by any prefix in the base file.
         A candidate prefix is covered if:
-        1. Its network address matches a base prefix in the trie
-        2. The matching base prefix length <= candidate prefix length
-           (i.e., base prefix is equal or broader than candidate)
+        Its network address matches a base prefix in the trie
         """
         try:
             candidate = ipaddress.ip_network(row.PFXS, strict=False)
         except ValueError:
             return 0
-        base_prefixlen = self._trie.lookup(candidate.network_address)
-        if base_prefixlen is not None and base_prefixlen <= candidate.prefixlen:
+        asn = self._trie.lookup(candidate)
+        if asn is not None:
             return 1
         return 0
 
@@ -125,8 +123,8 @@ def general_merge(
     base_network_index = BaseNetworkIndex()
     with open(base_file, "r") as file:
         for line in file:
-            pfx, _ = line.split(" ")
-            base_network_index.update(pfx)
+            pfx, asn = line.split(" ")
+            base_network_index.update(pfx, asn.strip())
 
     df_extra = extra_file_to_df(extra_file)
 

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -118,7 +118,6 @@ def general_merge(
     """
     Merge lists of IP networks into a base file.
     """
-    print("Creating network index from base file.")
     base_network_index = BaseNetworkIndex()
     with open(base_file, "r") as file:
         for line in file:

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -9,12 +9,11 @@ from kartograf.trie import IPTrie
 
 class BaseNetworkIndex:
     '''
-    A class whose _dict represents a mapping of the network number and
-    IP networks within that network for a given AS file.
+    An index of the base AS file's networks, backed by an IPTrie
+    mapping each network to its ASN.
 
     To check inclusion of a given IP network in the base AS file,
-    we can compare (see check_inclusion) the networks under the root network number
-    instead of all the networks in the base file.
+    contains_row looks up the nearest covering prefix in the trie.
     '''
 
     def __init__(self):

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -1,15 +1,11 @@
-from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 import ipaddress
-import math
-import os
 import shutil
-from types import SimpleNamespace
 import pandas as pd
 
 from kartograf.timed import timed
+from kartograf.trie import IPTrie
 from kartograf.util import get_root_network
-
 
 class BaseNetworkIndex:
     '''
@@ -21,63 +17,30 @@ class BaseNetworkIndex:
     instead of all the networks in the base file.
     '''
 
-
     def __init__(self):
-        self._dict = {4: {}, 6: {}}
-        self._v4_keys = self._dict[4].keys()
-        self._v6_keys = self._dict[6].keys()
+        self._trie = IPTrie()
 
-    def update(self, pfx):
+    def update(self, pfx, asn):
         try:
             ipn = ipaddress.ip_network(pfx)
         except ValueError:
             print(f"Invalid prefix provided: {pfx}")
             return
-
-        netw = int(ipn.network_address)
-        mask = int(ipn.netmask)
-        v = ipn.version
-        root_net = get_root_network(pfx)
-
-        if (root_net in self._v4_keys) or (root_net in self._v6_keys):
-            current = self._dict[v][root_net]
-            self._dict[v][root_net] = current + [(netw, mask, ipn.prefixlen)]
-        else:
-            self._dict[v].update({root_net: [(netw, mask, ipn.prefixlen)]})
-
-    def check_inclusion(self, row, root_net, version):
-        """
-        A network is a subnet of another if the bitwise AND of its IP and the base network's netmask
-        is equal to the base network IP, and the network's prefix length is larger or equal than the base network's
-        prefix length.
-        """
-        candidate = ipaddress.ip_network(row.PFXS)
-        for net, mask, prefixlen in self._dict[version][root_net]:
-            if candidate.prefixlen >= prefixlen and row.INETS & mask == net:
-                return 1
-        return 0
+        self._trie.insert(ipn, asn)
 
     def contains_row(self, row):
-        root_net = row.PFXS_LEADING
-        version = ipaddress.ip_network(row.PFXS).version
-        if version == 4 and (root_net in self._v4_keys):
-            return self.check_inclusion(row, root_net, version)
-        if version == 6 and (root_net in self._v6_keys):
-            return self.check_inclusion(row, root_net, version)
+        """
+        Check if the prefix in the row is covered by any prefix in the base file.
+        A candidate prefix is covered if its network address matches a prefix in the trie
+        """
+        try:
+            candidate = ipaddress.ip_network(row.PFXS)
+        except ValueError:
+            return 0
+        asn = self._trie.covering_asn(candidate)
+        if asn is not None:
+            return 1
         return 0
-
-    def get_serializable_dict(self):
-        """Return the internal dict for serialization to worker processes."""
-        return self._dict
-
-    @classmethod
-    def from_dict(cls, data_dict):
-        """Reconstruct a BaseNetworkIndex from a serialized dict."""
-        instance = cls()
-        instance._dict = data_dict
-        instance._v4_keys = instance._dict[4].keys()
-        instance._v6_keys = instance._dict[6].keys()
-        return instance
 
 @timed
 def merge_irr(context):
@@ -149,64 +112,27 @@ def extra_file_to_df(extra_file_path):
 
     return df_extra
 
-def process_chunk_worker(chunk_data, base_dict):
-    base = BaseNetworkIndex.from_dict(base_dict)
-
-    results = []
-    for original_idx, (net_int, pfx, pfx_leading) in chunk_data:
-        row = SimpleNamespace(PFXS=pfx, PFXS_LEADING=pfx_leading, INETS=net_int)
-
-        result = base.contains_row(row)
-        results.append((original_idx, result))
-    return results
-
-
-def pick_chunk_size(n_rows: int, workers: int | None = None,
-                    min_chunk: int = 5,
-                    max_chunk: int = 200_000) -> int:
-    if workers is None:
-        workers = os.cpu_count() or 4
-    chunk = math.ceil(n_rows / workers)
-    return max(min_chunk, min(max_chunk, chunk))
-
-
 def general_merge(
     base_file, extra_file, extra_filtered_file, out_file
 ):
     """
     Merge lists of IP networks into a base file.
     """
-    print("Merging extra prefixes that were not included in the base file.")
+    print("Creating network index from base file.")
     base_network_index = BaseNetworkIndex()
     with open(base_file, "r") as file:
         for line in file:
-            pfx, _ = line.split(" ")
-            base_network_index.update(pfx)
+            pfx, asn = line.split(" ")
+            base_network_index.update(pfx, asn.strip())
 
     df_extra = extra_file_to_df(extra_file)
 
-    len_df_extra = len(df_extra)
-    chunk_size = pick_chunk_size(len_df_extra)
-    chunks = []
-    chunk_data = []
-    for i, row in df_extra.iterrows():
-        chunk_data.append((i, (row.INETS, row.PFXS, row.PFXS_LEADING)))
-        if (i + 1) % chunk_size == 0 or i == len_df_extra - 1:
-            chunks.append(chunk_data)
-            chunk_data = []
+    print("Merging extra prefixes that were not included in the base file.")
+    extra_included = []
+    for row in df_extra.itertuples(index=False):
+        extra_included.append(base_network_index.contains_row(row))
 
-    all_results = []
-    with ProcessPoolExecutor() as executor:
-        base_dict = base_network_index.get_serializable_dict()
-        futures = [executor.submit(process_chunk_worker, chunk, base_dict) for chunk in chunks]
-
-        for future in futures:
-            all_results.extend(future.result())
-
-    # Sort by original index
-    all_results.sort(key=lambda x: x[0])
-
-    df_extra["INCLUDED"] = [result for _, result in all_results]
+    df_extra["INCLUDED"] = extra_included
 
     df_filtered = df_extra[df_extra.INCLUDED == 0]
 

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from kartograf.timed import timed
 from kartograf.trie import IPTrie
-from kartograf.util import get_root_network
+
 
 class BaseNetworkIndex:
     '''
@@ -84,32 +84,24 @@ def merge_pfx2as(context):
 
 
 def extra_file_to_df(extra_file_path):
-    extra_nets_int = []
     extra_asns = []
     extra_pfxs = []
-    extra_pfxs_leading = []
     with open(extra_file_path, "r") as file:
         for line in file:
             if not line.strip():
                 continue
             pfx, asn = line.split()
             try:
-                ipn = ipaddress.ip_network(pfx)
+                ipaddress.ip_network(pfx)
             except ValueError:
                 print(f"Invalid IP network: {pfx}, skipping")
                 continue
-            netw_int = int(ipn.network_address)
-            extra_nets_int.append(netw_int)
             extra_asns.append(asn.strip())
             extra_pfxs.append(pfx)
-            root_net = get_root_network(pfx)
-            extra_pfxs_leading.append(root_net)
 
     df_extra = pd.DataFrame({
-        "INETS": extra_nets_int,
         "ASNS": extra_asns,
         "PFXS": extra_pfxs,
-        "PFXS_LEADING": extra_pfxs_leading
         })
 
     return df_extra

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -90,7 +90,9 @@ def extra_file_to_df(extra_file_path):
     extra_pfxs_leading = []
     with open(extra_file_path, "r") as file:
         for line in file:
-            pfx, asn = line.split(" ")
+            if not line.strip():
+                continue
+            pfx, asn = line.split()
             try:
                 ipn = ipaddress.ip_network(pfx)
             except ValueError:
@@ -122,7 +124,9 @@ def general_merge(
     base_network_index = BaseNetworkIndex()
     with open(base_file, "r") as file:
         for line in file:
-            pfx, asn = line.split(" ")
+            if not line.strip():
+                continue
+            pfx, asn = line.split()
             base_network_index.update(pfx, asn.strip())
 
     df_extra = extra_file_to_df(extra_file)

--- a/kartograf/trie.py
+++ b/kartograf/trie.py
@@ -44,9 +44,27 @@ class IPTrie:
         node.asn = asn
 
     def lookup(self, ip):
-        if not isinstance(ip, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
-            raise TypeError("lookup expects an ip_address object")
+        if isinstance(ip, (ipaddress.IPv4Network, ipaddress.IPv6Network)):
+            return self._lookup_network(ip)
+        if isinstance(ip, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+            return self._lookup_address(ip)
+        raise TypeError("lookup expects an ip_address or ip_network object")
 
+    def _check_subtree(self, node):
+        '''
+        Check if subtree contains any networks recursively.
+        '''
+        if node.asn is not None:
+            result = node.asn
+        for bit in [0, 1]:
+            if node.children[bit] is not None:
+                result = self._check_subtree(node.children[bit])
+                if result is not None:
+                    return result
+        return None
+
+    def _lookup_address(self, ip):
+        """Lookup an IP address using longest prefix match."""
         if ip.version == 4:
             root = self._ipv4_root
             max_bits = 32
@@ -70,6 +88,48 @@ class IPTrie:
             last_asn = node.asn
 
         return last_asn
+
+    def _lookup_network(self, network):
+        """Lookup an IP network and check for overlap with existing networks.
+
+        For RPKI-based merging, we consider a network 'included' if it overlaps
+        with any RPKI network (exact match, subset, or superset). We only want
+        to add networks from less trusted sources if they don't overlap at all.
+        """
+        if network.version == 4:
+            root = self._ipv4_root
+            max_bits = 32
+        else:
+            root = self._ipv6_root
+            max_bits = 128
+
+        addr_int = int(network.network_address)
+        prefix_len = network.prefixlen
+
+        node = root
+        last_asn = None
+
+        # Traverse the trie to find RPKI networks that contain this candidate network
+        for i in range(max_bits):
+            if i<= prefix_len:
+                if node.asn is not None:
+                    last_asn = node.asn
+
+                bit = (addr_int >> (max_bits - 1 - i)) & 1
+                if node.children[bit] is None:
+                    break
+                node = node.children[bit]
+
+        # a network exists containing the candidate network
+        if last_asn is not None:
+            return last_asn
+
+        # exact match -- the candidate network is already included
+        if node.asn is not None:
+            return node.asn
+
+        # check if any networks would be overlapped by the candidate network
+        return self._check_subtree(node)
 
     def from_map_file(self, map_file):
         for line in map_file:

--- a/kartograf/trie.py
+++ b/kartograf/trie.py
@@ -50,19 +50,6 @@ class IPTrie:
             return self._lookup_address(ip)
         raise TypeError("lookup expects an ip_address or ip_network object")
 
-    def _check_subtree(self, node):
-        '''
-        Check if subtree contains any networks recursively.
-        '''
-        if node.asn is not None:
-            result = node.asn
-        for bit in [0, 1]:
-            if node.children[bit] is not None:
-                result = self._check_subtree(node.children[bit])
-                if result is not None:
-                    return result
-        return None
-
     def _lookup_address(self, ip):
         """Lookup an IP address using longest prefix match."""
         if ip.version == 4:
@@ -109,9 +96,9 @@ class IPTrie:
         node = root
         last_asn = None
 
-        # Traverse the trie to find RPKI networks that contain this candidate network
+        # Traverse the trie to find networks that contain this candidate network
         for i in range(max_bits):
-            if i<= prefix_len:
+            if i < prefix_len:
                 if node.asn is not None:
                     last_asn = node.asn
 
@@ -128,8 +115,7 @@ class IPTrie:
         if node.asn is not None:
             return node.asn
 
-        # check if any networks would be overlapped by the candidate network
-        return self._check_subtree(node)
+        return None
 
     def from_map_file(self, map_file):
         for line in map_file:

--- a/kartograf/trie.py
+++ b/kartograf/trie.py
@@ -22,54 +22,65 @@ class IPTrie:
 
     def insert(self, network, asn):
         if not isinstance(network, (ipaddress.IPv4Network, ipaddress.IPv6Network)):
-            raise TypeError("lookup expects an ip_address object")
+            raise TypeError("insert expects an ip_network object")
 
-        if network.version == 4:
-            root = self._ipv4_root
-            max_bits = 32
-        else:
-            root = self._ipv6_root
-            max_bits = 128
-
-        addr_int = int(network.network_address)
-        prefix_len = network.prefixlen
-
-        node = root
-        for i in range(prefix_len):
-            bit = (addr_int >> (max_bits - 1 - i)) & 1
-            if node.children[bit] is None:
-                node.children[bit] = TrieNode()
-            node = node.children[bit]
-
+        node, _ = self._walk(network.version, int(network.network_address),
+                             bits=network.prefixlen, create=True)
         node.asn = asn
 
     def lookup(self, ip):
+        """Lookup an IP address using longest prefix match."""
         if not isinstance(ip, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
             raise TypeError("lookup expects an ip_address object")
 
-        if ip.version == 4:
-            root = self._ipv4_root
+        _, last_asn = self._walk(ip.version, int(ip))
+        return last_asn
+
+    def covering_asn(self, network):
+        """Return the ASN of the network covering this one (exact match or
+        superset), or None.
+
+        For RPKI-based merging, we consider a network 'included' if it is
+        covered by an existing network (exact match or subset). We only want
+        to add networks from less trusted sources if they don't overlap at all.
+        """
+        if not isinstance(network, (ipaddress.IPv4Network, ipaddress.IPv6Network)):
+            raise TypeError("covering_asn expects an ip_network object")
+
+        _, last_asn = self._walk(network.version, int(network.network_address),
+                                 bits=network.prefixlen)
+        return last_asn
+
+    def _walk(self, version, addr_int, bits=None, create=False):
+        """Walk the trie along the bit path of addr_int.
+
+        Walks up to `bits` levels (default: every level, stopping when the
+        path runs out of children). With create=True, extends the path with
+        new nodes instead of stopping. Returns (node, last_asn): the node
+        where the walk stopped, and the ASN of the deepest node with an ASN
+        seen along the path.
+        """
+        if version == 4:
+            node = self._ipv4_root
             max_bits = 32
         else:
-            root = self._ipv6_root
+            node = self._ipv6_root
             max_bits = 128
 
-        addr_int = int(ip)
-        last_asn = None
-        node = root
-
-        for i in range(max_bits):
+        last_asn = node.asn
+        for i in range(max_bits if bits is None else bits):
+            bit = (addr_int >> (max_bits - 1 - i)) & 1
+            child = node.children[bit]
+            if child is None:
+                if not create:
+                    break
+                child = TrieNode()
+                node.children[bit] = child
+            node = child
             if node.asn is not None:
                 last_asn = node.asn
-            bit = (addr_int >> (max_bits - 1 - i)) & 1
-            if node.children[bit] is None:
-                break
-            node = node.children[bit]
 
-        if node.asn is not None:
-            last_asn = node.asn
-
-        return last_asn
+        return node, last_asn
 
     def from_map_file(self, map_file):
         for line in map_file:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -125,4 +125,3 @@ def test_merge_rpki_supersedes_irr_subnets(tmp_path):
     assert set(final_ips).isdisjoint(set(irr_ips)), (
         f"IRR subnets should not appear in merged output: {set(final_ips) & set(irr_ips)}"
     )
-

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -4,7 +4,7 @@ Test merging multiple sets of networks, as if they were independent AS files.
 from pathlib import Path
 import pytest
 
-from kartograf.merge import general_merge, pick_chunk_size
+from kartograf.merge import general_merge
 
 from .util.generate_data import (
     build_file_lines,
@@ -126,48 +126,3 @@ def test_merge_rpki_supersedes_irr_subnets(tmp_path):
         f"IRR subnets should not appear in merged output: {set(final_ips) & set(irr_ips)}"
     )
 
-def test_more_specific_base_does_not_suppress_extra_supernet(tmp_path):
-    '''
-    Test that a base more-specific prefix does not suppress an extra supernet
-    with the same network address.
-    A more specific network should not supersede a less specific network merged first.
-    In this test, 12.2.12.0/24 should not be merged since it is more specific than
-    12.0.0.0/8 and /9.
-    '''
-    rpki_path = tmp_path / "rpki_final.txt"
-    irr_path = tmp_path / "irr_final.txt"
-    rv_path = tmp_path / "pfx2asn_clean.txt"
-    merged_rpki_irr_path = tmp_path / "merged_file_rpki_irr.txt"
-    final_path = tmp_path / "merged_file_rpki_irr_rv.txt"
-
-    rpki_path.write_text("12.0.0.0/22 AS6269\n")
-    irr_path.write_text("12.0.0.0/8 AS7018\n12.0.0.0/9 AS7018\n")
-    rv_path.write_text("12.2.12.0/24 AS40724\n13.0.0.0/8 AS1239\n")
-
-    general_merge(rpki_path, irr_path, None, merged_rpki_irr_path)
-    general_merge(merged_rpki_irr_path, rv_path, None, final_path)
-
-    merged_rpki_irr = merged_rpki_irr_path.read_text()
-    final_result = final_path.read_text()
-
-    assert "12.0.0.0/22 AS6269\n" in merged_rpki_irr
-    assert "12.0.0.0/8 AS7018\n" in merged_rpki_irr
-    assert "12.0.0.0/9 AS7018\n" in merged_rpki_irr
-
-    assert "12.0.0.0/22 AS6269\n" in final_result
-    assert "12.0.0.0/8 AS7018\n" in final_result
-    assert "12.0.0.0/9 AS7018\n" in final_result
-    assert "12.2.12.0/24 AS40724\n" not in final_result
-    assert "13.0.0.0/8 AS1239\n" in final_result
-
-
-def test_pick_chunk_size():
-    '''
-    Test picking a chunk size for the merge function.
-    '''
-    assert pick_chunk_size(100, workers=16) == 7
-    assert pick_chunk_size(100, workers=4) == 25
-    # min_chunk wins
-    assert pick_chunk_size(10, workers=4) == 5
-    # min_chunk wins
-    assert pick_chunk_size(0) == 5

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -35,6 +35,22 @@ def _read_test_vectors(filepath):
                 all_in_result.append(network)
     return all_networks, all_in_result
 
+
+def test_extra_more_specific_does_not_supersede_base_supernet(tmp_path):
+    base_path = tmp_path / "base.txt"
+    extra_path = tmp_path / "extra.txt"
+    out_path = tmp_path / "out.txt"
+
+    base_path.write_text("12.0.0.0/8 AS7018\n")
+    extra_path.write_text("12.0.224.0/24 AS2386\n")
+
+    general_merge(base_path, extra_path, None, out_path)
+
+    result = out_path.read_text()
+
+    assert "12.0.0.0/8 AS7018\n" in result
+    assert "12.0.224.0/24 AS2386\n" not in result
+
 def test_merge_from_fixtures(tmp_path):
     '''
     Assert that general_merge merges subnets correctly,

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -4,7 +4,7 @@ Test merging multiple sets of networks, as if they were independent AS files.
 from pathlib import Path
 import pytest
 
-from kartograf.merge import general_merge, pick_chunk_size
+from kartograf.merge import general_merge
 from kartograf.prune import prune_entries
 
 from .util.generate_data import (
@@ -35,6 +35,22 @@ def _read_test_vectors(filepath):
             if in_result.strip() == "1":
                 all_in_result.append(network)
     return all_networks, all_in_result
+
+
+def test_extra_more_specific_does_not_supersede_base_supernet(tmp_path):
+    base_path = tmp_path / "base.txt"
+    extra_path = tmp_path / "extra.txt"
+    out_path = tmp_path / "out.txt"
+
+    base_path.write_text("12.0.0.0/8 AS7018\n")
+    extra_path.write_text("12.0.224.0/24 AS2386\n")
+
+    general_merge(base_path, extra_path, None, out_path)
+
+    result = out_path.read_text()
+
+    assert "12.0.0.0/8 AS7018\n" in result
+    assert "12.0.224.0/24 AS2386\n" not in result
 
 def test_merge_from_fixtures(tmp_path):
     '''
@@ -160,18 +176,6 @@ def test_more_specific_base_does_not_suppress_extra_supernet(tmp_path):
     assert "12.0.0.0/9 AS7018\n" in final_result
     assert "12.2.12.0/24 AS40724\n" not in final_result
     assert "13.0.0.0/8 AS1239\n" in final_result
-
-
-def test_pick_chunk_size():
-    '''
-    Test picking a chunk size for the merge function.
-    '''
-    assert pick_chunk_size(100, workers=16) == 7
-    assert pick_chunk_size(100, workers=4) == 25
-    # min_chunk wins
-    assert pick_chunk_size(10, workers=4) == 5
-    # min_chunk wins
-    assert pick_chunk_size(0) == 5
 
 
 def test_pruned_extras_merge_to_the_same_canonical_result(tmp_path):

--- a/tests/test_merge_base_class.py
+++ b/tests/test_merge_base_class.py
@@ -19,7 +19,7 @@ def _df_from_networks(networks, asn=123):
     return df
 
 
-def test_base_dict_create():
+def test_base_create():
     '''
     contains_row returns false when adding a row to an empty base file dict.
     '''
@@ -31,15 +31,15 @@ def test_base_dict_create():
         assert not base.contains_row(row)
 
 
-def test_base_dict_update():
+def test_base_update():
     '''
     contains_row returns true when adding a row already present in the base dict.
     '''
     base = BaseNetworkIndex()
     ipv4_network = "10.10.0.0/16"
     ipv6_network = "2c0f:ff90::/32"
-    base.update(ipv4_network)
-    base.update(ipv6_network)
+    base.update(ipv4_network, 123)
+    base.update(ipv6_network, 123)
     df_extra = _df_from_networks([ipv4_network, ipv6_network])
     for row in df_extra.itertuples(index=False):
         assert base.contains_row(row)
@@ -51,7 +51,7 @@ def test_check_included_subnet():
     '''
     base = BaseNetworkIndex()
     network = "10.10.0.0/16"
-    base.update(network)
+    base.update(network, 123)
     subnet = "10.10.0.0/21"
     df_extra = _df_from_networks([subnet])
     for row in df_extra.itertuples(index=False):

--- a/tests/test_merge_base_class.py
+++ b/tests/test_merge_base_class.py
@@ -1,7 +1,5 @@
-import ipaddress
 import pandas as pd
 from kartograf.merge import BaseNetworkIndex
-from kartograf.util import get_root_network
 
 
 def _df_from_networks(networks, asn=123):
@@ -9,13 +7,10 @@ def _df_from_networks(networks, asn=123):
     Create a one-row dataframe that holds the extra file rows in the expected format for contains_row().
     '''
     df = pd.DataFrame(
-        columns=["INETS", "ASNS", "PFXS", "PFXS_LEADING"],
+        columns=["ASNS", "PFXS"],
     )
     for network in networks:
-        ipn = ipaddress.ip_network(network)
-        root_net = get_root_network(network)
-        network_int = int(ipn.network_address)
-        df.loc[len(df)] = [network_int, asn, str(ipn), root_net]
+        df.loc[len(df)] = [asn, network]
     return df
 
 

--- a/tests/test_trie.py
+++ b/tests/test_trie.py
@@ -267,3 +267,17 @@ def test_lookup_rejects_invalid_string():
 
     with pytest.raises(TypeError):
         trie.lookup("not.an.ip.address")
+
+
+def test_lookup_network():
+    trie = IPTrie()
+    base = ip_network("10.1.0.0/16")
+    downstream = ip_network("10.1.0.0/21")
+    upstream = ip_network("10.0.0.0/8")
+    not_covered = ip_network("10.2.0.0/16")
+    trie.insert(base, "AS100")
+
+    assert trie.lookup(base)
+    assert trie.lookup(downstream)
+    assert not trie.lookup(upstream)
+    assert not trie.lookup(not_covered)

--- a/tests/test_trie.py
+++ b/tests/test_trie.py
@@ -267,3 +267,95 @@ def test_lookup_rejects_invalid_string():
 
     with pytest.raises(TypeError):
         trie.lookup("not.an.ip.address")
+
+
+def test_lookup_rejects_network():
+    trie = IPTrie()
+    trie.insert(ip_network("10.0.0.0/8"), "AS100")
+
+    with pytest.raises(TypeError):
+        trie.lookup(ip_network("10.1.0.0/16"))
+
+
+def test_covering_asn_rejects_address():
+    trie = IPTrie()
+    trie.insert(ip_network("10.0.0.0/8"), "AS100")
+
+    with pytest.raises(TypeError):
+        trie.covering_asn(ip_address("10.1.2.3"))
+
+
+@pytest.mark.parametrize("base,down,down_nonaligned,up,sib", [
+    ("10.1.0.0/16", "10.1.0.0/21", "10.1.128.0/17", "10.0.0.0/8", "10.2.0.0/16"),
+    ("2001:db8::/32", "2001:db8:8000::/33", "2001:db8:ffff::/48", "2001::/16", "2001:db9::/32"),
+])
+def test_covering_asn(base, down, down_nonaligned, up, sib):
+    trie = IPTrie()
+    trie.insert(ip_network(base), "AS100")
+
+    assert trie.covering_asn(ip_network(base)) == "AS100"
+    assert trie.covering_asn(ip_network(down)) == "AS100"
+    assert trie.covering_asn(ip_network(down_nonaligned)) == "AS100"
+    assert trie.covering_asn(ip_network(up)) is None
+    assert trie.covering_asn(ip_network(sib)) is None
+
+
+@pytest.mark.parametrize("outer,inner,query", [
+    ("10.0.0.0/8", "10.1.0.0/16", "10.1.2.0/24"),
+    ("2001::/16", "2001:db8::/32", "2001:db8:1234::/48"),
+])
+def test_covering_asn_returns_nearest_cover(outer, inner, query):
+    trie = IPTrie()
+    trie.insert(ip_network(outer), "AS100")
+    trie.insert(ip_network(inner), "AS200")
+
+    assert trie.covering_asn(ip_network(query)) == "AS200"
+    assert trie.covering_asn(ip_network(inner)) == "AS200"
+
+
+@pytest.mark.parametrize("default,inside", [
+    ("0.0.0.0/0", "10.1.2.3"),
+    ("::/0", "2001:db8::1"),
+])
+def test_covering_asn_default_route(default, inside):
+    trie = IPTrie()
+    trie.insert(ip_network(default), "AS_DEFAULT")
+
+    assert trie.covering_asn(ip_network(default)) == "AS_DEFAULT"
+    assert trie.covering_asn(ip_network(inside)) == "AS_DEFAULT"
+
+
+@pytest.mark.parametrize("host,miss", [
+    ("192.168.1.100/32", "192.168.1.101/32"),
+    ("2001:db8::1/128", "2001:db8::2/128"),
+])
+def test_covering_asn_single_host(host, miss):
+    trie = IPTrie()
+    trie.insert(ip_network(host), "AS_SINGLE")
+
+    assert trie.covering_asn(ip_network(host)) == "AS_SINGLE"
+    assert trie.covering_asn(ip_network(miss)) is None
+
+
+@pytest.mark.parametrize("base,other_family", [
+    ("10.1.0.0/16", "2001:db8::/32"),
+    ("2001:db8::/32", "10.1.0.0/16"),
+])
+def test_covering_asn_cross_family_is_none(base, other_family):
+    trie = IPTrie()
+    trie.insert(ip_network(base), "AS100")
+
+    assert trie.covering_asn(ip_network(other_family)) is None
+
+
+@pytest.mark.parametrize("base,supernet", [
+    ("12.0.0.0/22", "12.0.0.0/8"),
+    ("2001:db8:8000::/33", "2001:db8::/32"),
+])
+def test_covering_asn_supernet_is_not_covered(base, supernet):
+    # Merge regression: a more-specific base must not suppress an
+    # extra supernet with the same network address.
+    trie = IPTrie()
+    trie.insert(ip_network(base), "AS100")
+
+    assert trie.covering_asn(ip_network(supernet)) is None


### PR DESCRIPTION
Use the trie implementation in the merge process, replacing the concurrent, chunked, map-based process.

It turns out there was a bug in our implementation. When we called `contains_row` to check whether a network was included in the base, it only checks whether that candidate / incoming network is a subnet. But it could also be a super-net, i.e. a shorter prefix. In that case both would exist in the merged output, but would be logically conflicting; we want to consider the base (RPKI) entry as the valid one, and reject the candidate. 5b0eea38ec651b4bbc09a7bb67211c629335d92e ensures we never overwrite base/RPKI entries, whether the candidate is a subnet or supernet of an existing entry. 

Running a reproduction run against the latest collab run, the new final_result file is 3254 entries longer. A diff of the original final_result and the new one gives 15699 entries (1% of total), 95% (15003) of which were previously unassigned. This sounds about right, because we keep the RPKI entries which are often most specific. I'm not sure though.
The count of entries and file size stay about the same, as does the encoded (filled or unfilled) file size.

Minimal test changes, probably should add some edge case testing, but the merge tests pass without changes. 

Overall, this makes the merge code simpler and removes some dependencies. We can probably remove pandas entirely next with a few more changes. It also speeds up the merge process.

However this will break our reproducibility CI check.