### PR TITLE
test: fix test data generation bugs and improve merge test readability

### DIFF
--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -15,10 +15,10 @@ from .util.generate_data import (
 )
 
 
-def __tmp_paths(tmp_path):
+def _tmp_paths(tmp_path):
     return [tmp_path / p for p in ["rpki_final.txt", "irr_final.txt", "out.txt"]]
 
-def __read_test_vectors(filepath):
+def _read_test_vectors(filepath):
     '''
     Fixtures for IP networks are under tests/data.
     Read them and return the list of valid networks and the list of individual subnets in the file.
@@ -41,9 +41,9 @@ def test_merge_from_fixtures(tmp_path):
     i.e. subnets are merged into the root network appropriately.
     '''
     data_dir = Path(__file__).parent / "data"
-    base_nets, base_results = __read_test_vectors(data_dir / "base_file.csv")
+    base_nets, base_results = _read_test_vectors(data_dir / "base_file.csv")
     base_path = tmp_path / "base.txt"
-    extra_nets, extra_results = __read_test_vectors(data_dir / "extra_file.csv")
+    extra_nets, extra_results = _read_test_vectors(data_dir / "extra_file.csv")
     extra_path = tmp_path / "extra.txt"
     # write the networks to disk, generating ASNs for each network
     generate_ip_file(base_path, build_file_lines(base_nets, generate_asns(len(base_nets))))
@@ -59,12 +59,12 @@ def test_merge_from_fixtures(tmp_path):
     # with the expected results
     assert merged_networks == expected_networks
 
-def test_merge(tmp_path):
+def test_merge_identical_files(tmp_path):
     '''
     Assert that merging two identical files is a no-op.
     '''
     rpki_data = generate_file_items(100)
-    rpki_path, _, out_path = __tmp_paths(tmp_path)
+    rpki_path, _, out_path = _tmp_paths(tmp_path)
     generate_ip_file(rpki_path, rpki_data)
 
     general_merge(rpki_path, rpki_path, None, out_path)
@@ -88,7 +88,7 @@ def test_merge_disjoint(tmp_path):
     rpki_data = build_file_lines(rpki_ips, generate_asns(len(rpki_ips)))
     irr_data = build_file_lines(irr_ips, generate_asns(len(irr_ips)))
 
-    rpki_path, irr_path, out_path = __tmp_paths(tmp_path)
+    rpki_path, irr_path, out_path = _tmp_paths(tmp_path)
     generate_ip_file(rpki_path, rpki_data)
     generate_ip_file(irr_path, irr_data)
     general_merge(rpki_path, irr_path, None, out_path)
@@ -100,9 +100,9 @@ def test_merge_disjoint(tmp_path):
     assert set(final_ips) == (set(irr_ips) | set(rpki_ips))
 
 
-def test_merge_joint(tmp_path):
+def test_merge_rpki_supersedes_irr_subnets(tmp_path):
     '''
-    Test merging overlapping sets of IP networks.
+    Test that RPKI networks take priority over overlapping IRR subnets.
     '''
     overlap = 10
     rpki_data = generate_file_items(100)
@@ -111,7 +111,7 @@ def test_merge_joint(tmp_path):
     irr_ips = generate_subnets_from_base(rpki_ips, overlap)
     irr_data = build_file_lines(irr_ips, generate_asns(len(irr_ips)))
 
-    rpki_path, irr_path, out_path = __tmp_paths(tmp_path)
+    rpki_path, irr_path, out_path = _tmp_paths(tmp_path)
     generate_ip_file(rpki_path, rpki_data)
     generate_ip_file(irr_path, irr_data)
     general_merge(rpki_path, irr_path, None, out_path)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -2,6 +2,7 @@
 Test merging multiple sets of networks, as if they were independent AS files.
 '''
 from pathlib import Path
+import pytest
 
 from kartograf.merge import general_merge, pick_chunk_size
 
@@ -59,11 +60,12 @@ def test_merge_from_fixtures(tmp_path):
     # with the expected results
     assert merged_networks == expected_networks
 
-def test_merge_identical_files(tmp_path):
+@pytest.mark.parametrize("ip_type", ["v4", "v6"])
+def test_merge_identical_files(tmp_path, ip_type):
     '''
     Assert that merging two identical files is a no-op.
     '''
-    rpki_data = generate_file_items(100)
+    rpki_data = generate_file_items(100, ip_type=ip_type)
     rpki_path, _, out_path = _tmp_paths(tmp_path)
     generate_ip_file(rpki_path, rpki_data)
 
@@ -120,8 +122,9 @@ def test_merge_rpki_supersedes_irr_subnets(tmp_path):
         lines = f.readlines()
         final_ips = [item.split()[0] for item in lines]
 
-    # no subnets from irr_ips are included in the final merged network list
-    assert set(final_ips).isdisjoint(set(irr_ips))
+    assert set(final_ips).isdisjoint(set(irr_ips)), (
+        f"IRR subnets should not appear in merged output: {set(final_ips) & set(irr_ips)}"
+    )
 
 def test_pick_chunk_size():
     '''

--- a/tests/util/generate_data.py
+++ b/tests/util/generate_data.py
@@ -16,7 +16,7 @@ def generate_ip(ip_type="v4", subnet_size="16"):
         subnet_mask = int(ipaddress.IPv4Network(f"0.0.0.0/{subnet_size}", strict=False).netmask)
     elif ip_type == "v6":
         end_ip = int(ipaddress.IPv6Address("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"))
-        subnet_mask = int(ipaddress.IPv6Network(f"::::::::/{subnet_size}", strict=False).netmask)
+        subnet_mask = int(ipaddress.IPv6Network(f"::/{subnet_size}", strict=False).netmask)
     else:
         raise TypeError(f"invalid IP address type provided: {ip_type}")
 
@@ -30,9 +30,14 @@ def generate_ip(ip_type="v4", subnet_size="16"):
         return ipaddress.ip_network(str(network_addr) + f"/{subnet_size}")
     return None
 
+
 def generate_ip_networks(
-    count, ip_type="v4", subnet_range_start=8, subnet_range_end=24
+    count, ip_type="v4", subnet_range_start=None, subnet_range_end=None
 ):
+    if subnet_range_start is None:
+        subnet_range_start = 16 if ip_type == "v6" else 8
+    if subnet_range_end is None:
+        subnet_range_end = 48 if ip_type == "v6" else 24
     ips = set()
     while count > 0:
         random_subnet = randint(subnet_range_start, subnet_range_end)
@@ -57,7 +62,7 @@ def generate_subnets_from_base(base_networks, count):
     subnets = []
     for network in base_networks[:count]:
         subnet = list(ipaddress.ip_network(network).subnets())[0]
-        subnets.append(str(subnet.network_address))
+        subnets.append(str(subnet))
     return subnets
 
 


### PR DESCRIPTION
Reviewed `test_merge.py` and found two bugs in `generate_data.py` that made tests less effective than intended.

Bug 1: `generate_subnets_from_base` used `str(subnet.network_address)` which returns bare addresses like `'10.0.0.0'` instead of CIDR notation `'10.0.0.0/17'`. The overlap assertion in `test_merge_joint` compared these against merge output entries like `'10.0.0.0/16'`. Since bare addresses never match CIDR strings, `isdisjoint` was always true regardless of whether the merge actually worked.

Bug 2: `generate_ip` used `'::::::::'` as the IPv6 zero address, which is invalid notation (`::` is correct — only one `::` is permitted per address). Every call with `ip_type="v6"` raised `AddressValueError`, so IPv6 test data generation has never worked. Nothing in the test suite exercised that path before, so the mistake stayed hidden until IPv6 coverage was added here.

Other changes:
- Rename `__tmp_paths`/`__read_test_vectors` to single underscore (name mangling is only meaningful inside classes)
- Rename `test_merge` → `test_merge_identical_files`, `test_merge_joint` → `test_merge_rpki_supersedes_irr_subnets`
- Parametrize `test_merge_identical_files` for v4/v6 instead of duplicating the test
- Add assertion message to the overlap test for better failure diagnostics