### PR TITLE
Fail on rpki-client errors and surface validation problems

### DIFF
--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -110,6 +110,13 @@ def fetch_rpki_db(context):
                 if result.stderr:
                     logs.write(result.stderr.decode())
 
+        if result.returncode != 0:
+            print(f"rpki-client exited with code {result.returncode} "
+                  "during fetch:")
+            if result.stderr:
+                print("\n".join(result.stderr.decode().splitlines()[-10:]))
+            sys.exit(1)
+
         parse_ccr_hashes(result.stdout.decode() if result.stdout else "")
 
     print(f"Downloaded RPKI Data, hash sum: {calculate_sha256_directory(context.data_dir_rpki_cache)}")

--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -158,6 +158,12 @@ def validate_rpki_db(context):
                                  capture_output=True,
                                  check=False)
 
+        if result.returncode != 0:
+            print("rpki-client validation batch failed "
+                  f"(exit {result.returncode}):")
+            print(result.stderr.decode() if result.stderr else "(no stderr)")
+            sys.exit(1)
+
         if result.stderr and context.debug_log:
             stderr_output = result.stderr.decode()
             with debug_file_lock:
@@ -186,6 +192,12 @@ def validate_rpki_db(context):
 
         with open(result_path, 'w') as f:
             json.dump(s, f)
+
+    # rpki-client emits exactly one JSON object per -f input file
+    if len(results_json) != len(files):
+        print(f"Validation incomplete: {len(results_json)} results for "
+              f"{len(files)} files! Exiting.")
+        sys.exit(1)
 
     print(f"{len(results_json)} RKPI ROAs validated\nSaved to: {result_path.name}\nFile hash: {calculate_sha256(result_path)}")
 


### PR DESCRIPTION
Follow-up to the discussion in bitcoin-core/asmap-data#60. 
Kartograf currently ignores rpki-client's exit code and drops its stderr unless --debug is set. All the failures we saw degraded silently into plausible looking but wrong maps: an empty cache (69MB result), an all-invalid validation (sipa's 72MB result) and a partial fetch (nkaretnikov's 62MB result in bitcoin-core/asmap-data#51).

This fails when rpki-client exits with an error, when validation results get lost (e.g. a batch got killed) and when the majority of ROAs is invalid. 

A reproduction run over the 1783008000 data with these changes produces the identical result hash (35a4b28f), so the checks are invisible on healthy runs. Complements #146.