### PR TITLE
Keep last object when file has no trailing blank

### DIFF
--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -38,13 +38,18 @@ def parse_irr(context):
 
         # Parse the RPSL objects in the IRR DB into Python Dicts
         for line in lines:
-            if line == '\n':
-                entry_list.append(current_entry)
-                current_entry = {}
+            if not line.strip():
+                if current_entry:
+                    entry_list.append(current_entry)
+                    current_entry = {}
             else:
                 if ":" in line:
                     k, v = line.strip().split(':', 1)
                     current_entry[k.strip()] = v.strip()
+
+        # Do not lose the final object when the file lacks a trailing blank line.
+        if current_entry:
+            entry_list.append(current_entry)
 
         for entry in entry_list:
             is_complete = all(k in entry for k in ("origin", "source"))

--- a/tests/data/irr_ripe.txt
+++ b/tests/data/irr_ripe.txt
@@ -81,3 +81,10 @@ route:          212.19.0.0/24
 descr:          Test Incomplete Entry
 origin:         AS12345
 
+route:          212.20.0.0/24
+descr:          Test Network No Trailing Blank
+origin:         AS12345
+mnt-by:         TEST-MNT
+created:        2023-01-01T00:00:00Z
+last-modified:  2023-01-01T00:00:00Z
+source:         RIPE

--- a/tests/test_irr_parse.py
+++ b/tests/test_irr_parse.py
@@ -42,5 +42,8 @@ def test_parse_validation_cases(tmp_path):
     # Test incomplete entry (no source in data)
     assert "212.19.0.0/24 AS12345" not in content
 
+    # Last complete object has no trailing blank in the fixture
+    assert "212.20.0.0/24 AS12345" in content
+
     # Test expected set
-    assert content == ["193.254.30.0/24 AS12726", "212.166.64.0/19 AS12321", "212.80.191.0/24 AS12541", "212.16.0.0/24 AS12346", "212.17.0.0/24 AS12347", "2345:2ca::/32 AS12345" ]
+    assert content == ["193.254.30.0/24 AS12726", "212.166.64.0/19 AS12321", "212.80.191.0/24 AS12541", "212.16.0.0/24 AS12346", "212.17.0.0/24 AS12347", "2345:2ca::/32 AS12345", "212.20.0.0/24 AS12345"]


### PR DESCRIPTION
`parse_irr` only appends the current RPSL object when it sees `line == '\n'`. It never flushes after the last line of the file. If an IRR dump has no trailing blank after the final object, that object never reaches `irr_final.txt`.

That shows up on real collaborative-run inputs. I reproduced launches `1780588800` and `1783008000` from the stored raw inputs with RPKI + IRR + RouteViews, once on current master (deca9cb) and once with only this parse fix, same inputs both times:


| Launch     | irr_final              | final_result      | new / reassign / unassign | new final line           |
| ---------- | ---------------------- | ----------------- | ------------------------- | ------------------------ |
| 1780588800 | 2170503 → 2170508 (+5) | 1371595 → 1371596 | 1 / 0 / 0                 | 102.203.33.0/24 AS328722 |
| 1783008000 | 2353080 → 2353085 (+5) | 1510770 → 1510771 | 1 / 0 / 0                 | 102.202.78.0/24 AS328553 |


Of the five recovered `irr_final` lines each time, the ones already exact or covered by RPKI do not change the map. What remains in `final_result` is an AFRINIC `/24` with no RPKI cover.

Master rebuild for `1783008000` matches the attested `final_result.txt` sha256 `853229f2b3854ca6360ebee3557b55a2693bc6220cf220052708e47e5450087e`. With the fix that hash becomes `f1fc26cf4a4b425b21a5e016171de3bd0c20d15341633668d71fbb806f22a00a` (one new assignment; no reassignments or unassignments).

For `1780588800` the master rebuild is `ae50a4153ec0953fb030e2f6b0d1c964eaf6be0d41a2b5417702f6b8e2ff659c` and with the fix `2a1f6b492eb728227a7b3df14a40545acf136f9348de675f681f83ecdc45ee1d`. Same inputs do not keep the same collaborative `final_result` hash after this lands. Small next to #145, but it is a real map change.

I also checked those two `/24`s against local bitnod.es snapshots (including days around the launches): no clearnet peers in either prefix, so no observed node goes from unmapped to mapped.

Related: #137 / #138 (@SuvidhJ). Those also proposed a merge rewrite and a worker cap. Left out here (see comment on #137).