### PR TITLE
fix Nix PATH prepending

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -26,9 +26,9 @@ in
           '';
           fixupPhase = ''
             wrapProgram $out/bin/kartograf \
-              --set PYTHONPATH $out/lib:$PYTHONPATH
-            wrapProgram $out/bin/kartograf \
-              --set PATH ${rpki-client}/bin:$PATH
+              --set PYTHONPATH $out/lib:$PYTHONPATH \
+              --prefix PATH : ${rpki-client}/bin \
+              --prefix PATH : ${pythonBuildDeps}/bin
           '';
           meta = with pkgs.lib; {
             description = "Kartograf: IP to ASN mapping for everyone";


### PR DESCRIPTION
The PATH manipulations in `nix/package.nix` replace the PATH and do not include the Python dependencies' paths, as surfaced by @jorisstrakeljahn . 

This handles the PATH wrapping more cleanly, by merging the two wrapProgram calls into one, switching `--set PATH` to `--prefix PATH` so the existing PATH isn't clobbered. It also add `--prefix PATH : ${pythonBuildDeps}/bin` so the `#!/usr/bin/env -S python3 -u` shebang resolves Nix's Python, not the user's local path when running within the Nix context. 

Test by entering a nix shell with `nix develop` and running. You can also inspect the python dependency paths to ensure they are the Nix ones, not the local ones.