### PR TITLE
Bump support rpki-client to 9.9

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 # Container description file for running kartograf
 FROM python:3.13
-ARG RPKI_VERSION=9.8
+ARG RPKI_VERSION=9.9
 
 # Download and install rpki-client from source
 RUN set -x && \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ podman rm kartograf-run
 
 #### rpki-client
 
-Kartograf requires `rpki-client` version 9.6 or higher to be installed locally. Many package managers have `rpki-client`, however please note that typically only the latest version is available. Kartograf is currently tested to work with `rpki-client` 9.6 - 9.8. If a new release is available that breaks compatibility, you may need to build a compatible `rpki-client` version yourself if your preferred package manager does not have a compatible version available. In that case, see the [instructions in the rpki-client-portable project](https://github.com/rpki-client/rpki-client-portable/blob/master/INSTALL).
+Kartograf requires `rpki-client` version 9.6 or higher to be installed locally. Many package managers have `rpki-client`, however please note that typically only the latest version is available. Kartograf is currently tested to work with `rpki-client` 9.6 - 9.9. If a new release is available that breaks compatibility, you may need to build a compatible `rpki-client` version yourself if your preferred package manager does not have a compatible version available. In that case, see the [instructions in the rpki-client-portable project](https://github.com/rpki-client/rpki-client-portable/blob/master/INSTALL).
 
 ```
 # Linux/BSD

--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1776860989,
-        "narHash": "sha256-854I928GfnePjIA05Xl9JQUg9KwbrIjmcupchy1Qqzo=",
+        "lastModified": 1787770239,
+        "narHash": "sha256-5ZwUPUjPA9zWjOX5cAdCRPu+KknuD4i0Q/ShO0GEu1Y=",
         "owner": "asmap",
         "repo": "rpki-client-nix",
-        "rev": "112cb9b1431430936c37dbbdc3764febc0263a31",
+        "rev": "63a0d0331cd1f56c391d34e6b2f16a462dd6e093",
         "type": "github"
       },
       "original": {
@@ -48,34 +48,34 @@
     "rpki-client-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1776199275,
-        "narHash": "sha256-PejvnEGr+K+g+vLgO+JroZXRAa1LUJUzCwDVm8AyScY=",
+        "lastModified": 1787400752,
+        "narHash": "sha256-YYEz2F0R15Fr+eYO9RIXW8+BOh3sJA7acmN1d4ka0ns=",
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "15554f28842d7d9e6cc31eab5f95e36053b42f35",
+        "rev": "cf5bdfba24b683968c406ee516dac65debbe2e69",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "15554f28842d7d9e6cc31eab5f95e36053b42f35",
+        "rev": "cf5bdfba24b683968c406ee516dac65debbe2e69",
         "type": "github"
       }
     },
     "rpki-openbsd-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1776072166,
-        "narHash": "sha256-sQfoPeWFKQXcaIgEgiCbBrdJ9s1pzXTqz25Y+OH/q4k=",
+        "lastModified": 1787401336,
+        "narHash": "sha256-SVAe68oVTuQHcVD+KbbRPm0wNrrV4kc8VG20a1BUZ1w=",
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "8aa0236d10a6c5e25fb282eb030069dae3d3abbe",
+        "rev": "65b0882149d7c1a22208b0415b9ece507d8f9522",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "8aa0236d10a6c5e25fb282eb030069dae3d3abbe",
+        "rev": "65b0882149d7c1a22208b0415b9ece507d8f9522",
         "type": "github"
       }
     },

--- a/kartograf/util.py
+++ b/kartograf/util.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 import time
 
-RPKI_VERSION = 9.8
+RPKI_VERSION = 9.9
 
 
 def calculate_sha256(file_path):


### PR DESCRIPTION
This is still missing the flake file bump that depends on this: https://github.com/asmap/rpki-client-nix/pull/22 hence still draft.

Since we merged two PRs that could change the resulting hash and only backtested each in isolation, there are no public hash references that I could compare to safely. So I re-ran the last three collaborative runs with the current master and 9.8 as well as 9.9 and I only saw matches, so I don't suspect and issues with compatibility. Looking at the release notes everything looks safe as well.

I would still ask reviewers to please run one or ideally more older reproduction run with 9.8 and master before upgrading and then compare them to your result with master and 9.9 to see if there are any mismatches.

Here are the hash results of my runs (all matched on 9.8 and 9.9)
- 1786032000: `fedb4ffd0fb9c0202c1e1839c2184edc58f0f0a7ff0625de40c2dc927fe9d823`
- 1783008000: `ef9b847c3fb6e822491fdb5317917ff854913a506faae2b18dae551912daedd8`
- 1780588800: `e1b55e12ec68ae5da0b849fa89b3b378851ff29a36dfa0a27f8a1bb2c15a0c71`