### PR TITLE
rpki: Fix LACNIC TAL download URL

### DIFF
--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -20,7 +20,7 @@ TAL_URLS = {
     "afrinic": "http://rpki.afrinic.net/tal/afrinic.tal",
     "apnic": "https://tal.apnic.net/tal-archive/apnic-rfc7730-https.tal",
     "arin": "https://www.arin.net/resources/manage/rpki/arin.tal",
-    "lacnic": "https://www.lacnic.net/rpki/lacnic.tal",
+    "lacnic": "https://www.lacnic.net/innovaportal/file/4983/1/lacnic.tal",
     "ripe": "https://tal.rpki.ripe.net/ripe-ncc.tal"
 }
 


### PR DESCRIPTION
LACNIC relaunched its website in mid August 2026. The URL we used, https://www.lacnic.net/rpki/lacnic.tal, was a CMS alias that used to redirect to the TAL file. The new site now answers it with HTTP 200 and an HTML page, which we saved as lacnic.tal. rpki-client then fails to parse it and exits before syncing anything, and every run ends up with an empty RPKI cache. This means kartograf is currently broken for building new maps.