### PR TITLE
rpki: Use the TALs shipped with rpki-client (2nd attempt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,3 @@ Tests are located under `tests`, and can be run with `pytest`. Run `pytest tests
 ## Acknowledgements
 
 [Job Snijders](https://github.com/job)
-
-## Legal note
-
-In order to properly validate RPKI ROAs Kartograf downloads all RIR Trust Anchors via each users TAL. Usage of the ARIN TAL file requires users of Kartograf to agree to [ARIN's Relying Party Agreement](https://www.arin.net/resources/manage/rpki/rpa.pdf).

--- a/kartograf/context.py
+++ b/kartograf/context.py
@@ -47,7 +47,6 @@ class Context:
 
         self.data_dir_irr = str(Path(self.data_dir) / "irr")
         self.data_dir_rpki_cache = str(Path(self.data_dir) / "rpki" / "cache")
-        self.data_dir_rpki_tals = str(Path(self.data_dir) / "rpki" / "tals")
         self.data_dir_collectors = str(Path(self.data_dir) / "collectors")
         # Out dir
         self.out_dir = str(cwd / "out" / self.epoch_dir)
@@ -64,7 +63,6 @@ class Context:
         # We skip creating the folders if we are reproducing a run.
         if not self.reproduce:
             Path(self.data_dir_rpki_cache).mkdir(parents=True)
-            Path(self.data_dir_rpki_tals).mkdir(parents=True)
             if self.args.irr:
                 Path(self.data_dir_irr).mkdir(parents=True)
             if self.args.routeviews:

--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -7,7 +7,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
 from threading import Lock
 from pathlib import Path
-import requests
 from tqdm import tqdm
 
 from kartograf.timed import timed
@@ -15,14 +14,6 @@ from kartograf.util import (
     calculate_sha256,
     calculate_sha256_directory,
 )
-
-TAL_URLS = {
-    "afrinic": "http://rpki.afrinic.net/tal/afrinic.tal",
-    "apnic": "https://tal.apnic.net/tal-archive/apnic-rfc7730-https.tal",
-    "arin": "https://www.arin.net/resources/manage/rpki/arin.tal",
-    "lacnic": "https://www.lacnic.net/innovaportal/file/4983/1/lacnic.tal",
-    "ripe": "https://tal.rpki.ripe.net/ripe-ncc.tal"
-}
 
 STABLE_REPO_URLS = [
     "rpki.arin.net",
@@ -40,36 +31,6 @@ STABLE_REPO_URLS = [
     "repo-rpki.idnic.net"
 ]
 
-def download_rir_tals(context):
-    tals = []
-
-    for rir, url in TAL_URLS.items():
-        try:
-            response = requests.get(url, timeout=600)
-            response.raise_for_status()
-
-            tal_path = Path(context.data_dir_rpki_tals) / f"{rir}.tal"
-            with open(tal_path, 'wb') as file:
-                file.write(response.content)
-
-            print(f"Downloaded TAL for {rir.upper()} to {tal_path.name}, file hash: {calculate_sha256(tal_path)}")
-            tals.append(tal_path)
-
-        except requests.RequestException as e:
-            print(f"Error downloading TAL for {rir.upper()}: {e}")
-            sys.exit(1)
-
-
-def data_tals(context):
-    tal_paths = list(Path(context.data_dir_rpki_tals).rglob('*.tal'))
-    # We need to have 5 TALs, one from each RIR
-    if len(tal_paths) == 5:
-        return tal_paths
-
-    print("Not all 5 TALs could be downloaded.")
-    sys.exit(1)
-
-
 @timed
 def fetch_rpki_db(context):
     """
@@ -83,12 +44,10 @@ def fetch_rpki_db(context):
     since the default writes several hundred MB of data. The metrics
     data is not used.
     """
-    # Download TALs and persist them in the RPKI data folder
-    download_rir_tals(context)
+    # Without -t, rpki-client uses the RIR TALs it ships with
     with TemporaryDirectory(prefix="rpki-out-") as tmpdir:
-        tal_options = [item for path in data_tals(context) for item in ('-t', path)]
         run_args = ["rpki-client", "-m", "-d", context.data_dir_rpki_cache,
-                     "-P", context.epoch] + tal_options
+                    "-P", context.epoch]
         print("Downloading RPKI Data, this may take a while.")
 
         if context.stable_repos:
@@ -137,8 +96,6 @@ def validate_rpki_db(context):
     rpki_raw_file = 'rpki_raw.json'
     result_path = Path(context.out_dir_rpki) / rpki_raw_file
 
-    tal_options = [item for path in data_tals(context) for item in ('-t', path)]
-
     debug_file_lock = Lock()
 
     if context.debug_log:
@@ -153,8 +110,7 @@ def validate_rpki_db(context):
                                  context.data_dir_rpki_cache,
                                  "-P",
                                  context.epoch,
-                                 ] + tal_options +
-                                 ["-f"] + batch,  # -f has to be last
+                                 "-f"] + batch,  # -f has to be last
                                  capture_output=True,
                                  check=False)
 

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -11,7 +11,7 @@ from kartograf.bogon import (
     is_out_of_encoding_range,
 )
 from kartograf.prune import prune_entries
-from kartograf.rpki.fetch import data_tals, parse_ccr_hashes
+from kartograf.rpki.fetch import parse_ccr_hashes
 from kartograf.timed import timed
 from kartograf.util import parse_pfx
 
@@ -144,9 +144,8 @@ def compute_ccr_hashes(context):
     data is not used.
     """
     with TemporaryDirectory(prefix="rpki-out-") as tmpdir:
-        tal_options = [item for path in data_tals(context) for item in ('-t', path)]
         run_args = ["rpki-client", "-m", "-n", "-d", context.data_dir_rpki_cache,
-                     "-P", context.epoch] + tal_options + [tmpdir]
+                    "-P", context.epoch, tmpdir]
         result = subprocess.run(run_args,
                                 capture_output=True,
                                 check=False)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -72,11 +72,6 @@ def test_directory_creation(parser, tmp_path):
     assert Path(rpki_cache).exists()
     assert Path(rpki_cache).parent.name == "rpki"
 
-    rpki_tals = context.data_dir_rpki_tals
-    assert isinstance(rpki_tals, str)
-    assert Path(rpki_tals).exists()
-    assert Path(rpki_tals).parent.name == "rpki"
-
     data_dir_irr = context.data_dir_irr
     assert isinstance(data_dir_irr, str)
     assert Path(data_dir_irr).exists()


### PR DESCRIPTION
This is a revised version of #70.

We are currently managing the TALs ourselves, download them and give them to rpki-client as options. We had to do this because rpki-client didn't include the ARIN TAL in their releases for a while because of some licensing concerns: https://github.com/rpki-client/rpki-client-portable/issues/80 However, in January ARIN revised the license and so now all TALs will be included in the releases again: https://github.com/rpki-client/rpki-client-portable/commit/05de5a20a69f30a7d99ee2bd24d2512f28dc158f

This change used to depend on rpki-client 9.5 and so at the time when that was fairly recent we held off on making the change. But by now our minimum version is 9.6 already. And the issue we saw with #152 showed that it would probably better for us to rely on the people that have a bit closer eye changes in the RPKI space. Also nice that we can remove a bunch of code.