### PR TITLE
tests: Skip generated subnets that already exist in the base networks

### DIFF
--- a/tests/util/generate_data.py
+++ b/tests/util/generate_data.py
@@ -61,8 +61,10 @@ def generate_asns(count):
 def generate_subnets_from_base(base_networks, count):
     subnets = []
     for network in base_networks[:count]:
-        subnet = list(ipaddress.ip_network(network).subnets())[0]
-        subnets.append(str(subnet))
+        subnet = str(list(ipaddress.ip_network(network).subnets())[0])
+        # The randomly generated base can already contain this subnet
+        if subnet not in base_networks:
+            subnets.append(subnet)
     return subnets
 
 


### PR DESCRIPTION
This fixes a flaky test issue that was observed in #123 and I described what I think the issue is here: https://github.com/asmap/kartograf/pull/123#issuecomment-5309879070