### PR TITLE
Prune entries that don't change the encoded asmap file

### DIFF
--- a/.github/workflows/test-reproduction-run.yml
+++ b/.github/workflows/test-reproduction-run.yml
@@ -37,5 +37,5 @@ jobs:
         output=$(nix develop --command ./run map -r tests/data/1762444800 -t 1762444800 2>&1)
         echo "$output"
 
-        echo "$output" | grep -q 'b74e6f77817674e3b05232dee8153cf886e96887bd6321aa5028d6ed7ca96cac'
+        echo "$output" | grep -q 'bd43e98d95d5905eb16ccdcfdb35d9e19e090e7801e94829b0540988dbffc18d'
         echo "Output matches the expected value"

--- a/kartograf/collectors/parse.py
+++ b/kartograf/collectors/parse.py
@@ -5,6 +5,7 @@ from kartograf.bogon import (
     is_bogon_asn,
     is_out_of_encoding_range,
 )
+from kartograf.prune import prune_entries
 from kartograf.timed import timed
 from kartograf.util import parse_pfx
 
@@ -14,9 +15,9 @@ def parse_routeviews_pfx2as(context):
     raw_file = Path(context.out_dir_collectors) / "pfx2asn.txt"
     clean_file = Path(context.out_dir_collectors) / "pfx2asn_clean.txt"
     context.cleanup_out_files.append(raw_file)
-    written_lines = 0
+    entries = []
 
-    with open(raw_file, 'r') as raw, open(clean_file, 'w') as clean:
+    with open(raw_file, 'r') as raw:
         lines = raw.readlines()
         for line in lines:
             # CAIDA PFX2AS files can contain multi-origin routes as well as
@@ -38,8 +39,7 @@ def parse_routeviews_pfx2as(context):
                             logs.write(f"Routeviews: parser encountered an invalid IP network: {prefix}")
                     continue
 
-                clean.write(f"{prefix} {asn}\n")
-                written_lines += 1
+                entries.append((prefix, asn))
                 continue
 
             # If the line contains a multi-origin route (signified by the _)
@@ -70,7 +70,12 @@ def parse_routeviews_pfx2as(context):
             if context.max_encode and is_out_of_encoding_range(asn, context.max_encode):
                 continue
 
-            clean.write(f"{prefix} {asn}\n")
-            written_lines += 1
+            entries.append((prefix, asn))
 
-    print("Entries after cleanup:", written_lines)
+    entries, pruned = prune_entries(entries)
+    with open(clean_file, 'w') as clean:
+        for prefix, asn in entries:
+            clean.write(f"{prefix} {asn}\n")
+
+    print("Entries after cleanup:", len(entries))
+    print(f"Redundant entries pruned: {pruned}")

--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -9,6 +9,7 @@ from kartograf.bogon import (
     is_bogon_asn,
     is_out_of_encoding_range,
 )
+from kartograf.prune import prune_entries
 from kartograf.timed import timed
 from kartograf.util import parse_pfx, rir_from_str
 
@@ -116,7 +117,10 @@ def parse_irr(context):
 
     print("Found valid, unique entries:", len(output_cache))
 
+    entries = [(route, origin) for route, [origin, _] in output_cache.items()]
+    entries, pruned = prune_entries(entries)
+    print(f"Redundant entries pruned: {pruned}")
+
     with open(irr_res, "a+") as irr:
-        for route, [origin, _] in output_cache.items():
-            line_out = f"{route} {origin}\n"
-            irr.write(line_out)
+        for route, origin in entries:
+            irr.write(f"{route} {origin}\n")

--- a/kartograf/prune.py
+++ b/kartograf/prune.py
@@ -1,0 +1,45 @@
+"""
+Drop entries that do not change the map.
+
+Maps use longest prefix match, so an entry whose nearest covering prefix
+maps to the same ASN never wins a lookup. Removing such entries makes the
+output canonical: files that encode the same map are identical.
+"""
+import socket
+
+
+def _parse_prefix(prefix):
+    """Return (IP version, network address as int, prefix length)."""
+    addr, _, prefixlen = prefix.partition("/")
+    if ":" in addr:
+        return 6, int.from_bytes(socket.inet_pton(socket.AF_INET6, addr), "big"), int(prefixlen)
+    return 4, int.from_bytes(socket.inet_pton(socket.AF_INET, addr), "big"), int(prefixlen)
+
+
+def _sort_key(entry):
+    """One int per entry ordering by (version, network, prefix length)."""
+    version, net_int, prefixlen = _parse_prefix(entry[0])
+    return (version << 136) | (net_int << 8) | prefixlen
+
+
+def prune_entries(entries):
+    """
+    Drop every (prefix, asn) entry whose nearest covering entry has the same
+    ASN. Returns the kept entries, sorted by IP version, network address and
+    prefix length, and the number of dropped entries.
+    """
+    entries = sorted(entries, key=_sort_key)
+    kept = []
+    # Covering prefixes that are still open, as (version, last address, asn).
+    # Only kept entries are pushed, a dropped entry has the same ASN as its cover.
+    stack = []
+    for prefix, asn in entries:
+        version, net_int, prefixlen = _parse_prefix(prefix)
+        while stack and (stack[-1][0] != version or stack[-1][1] < net_int):
+            stack.pop()
+        if stack and stack[-1][2] == asn:
+            continue
+        bits = 32 if version == 4 else 128
+        stack.append((version, net_int | ((1 << (bits - prefixlen)) - 1), asn))
+        kept.append((prefix, asn))
+    return kept, len(entries) - len(kept)

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -10,6 +10,7 @@ from kartograf.bogon import (
     is_bogon_asn,
     is_out_of_encoding_range,
 )
+from kartograf.prune import prune_entries
 from kartograf.rpki.fetch import data_tals, parse_ccr_hashes
 from kartograf.timed import timed
 from kartograf.util import parse_pfx
@@ -106,11 +107,12 @@ def parse_rpki(context):
                     # No duplicate, add to cache
                     output_cache[prefix] = [asn, valid_until, valid_since]
 
-    with open(rpki_res, "w") as asmap:
-        for prefix, [asn, _, _] in output_cache.items():
-            line_out = f"{prefix} AS{asn}"
+    entries = [(prefix, f"AS{asn}") for prefix, [asn, _, _] in output_cache.items()]
+    entries, pruned = prune_entries(entries)
 
-            asmap.write(line_out + '\n')
+    with open(rpki_res, "w") as asmap:
+        for prefix, asn in entries:
+            asmap.write(f"{prefix} {asn}\n")
             out_count += 1
 
     context.cleanup_out_files.append(raw_input)
@@ -120,6 +122,7 @@ def parse_rpki(context):
     print(f'Invalids found: {invalids}')
     print(f'Incompletes: {incompletes}')
     print(f'Non-ROA files: {not_roas}')
+    print(f'Redundant entries pruned: {pruned}')
 
     if out_count == 0:
         print("No valid RPKI assignments found! Exiting.")

--- a/kartograf/sort.py
+++ b/kartograf/sort.py
@@ -1,6 +1,7 @@
 import ipaddress
 from pathlib import Path
 
+from kartograf.prune import prune_entries
 from kartograf.timed import timed
 
 
@@ -16,12 +17,16 @@ def sort_result_by_pfx(context):
         out_file = Path(context.out_dir_rpki) / "rpki_final.txt"
 
     with open(out_file, 'r') as file:
-        prefixes = file.read().splitlines()
+        entries = [tuple(line.split()) for line in file if line.strip()]
+
+    # Catches entries that only became redundant through the merge, e.g. an
+    # RPKI /24 under an IRR /23 with the same ASN.
+    entries, pruned = prune_entries(entries)
+    print(f"Redundant entries pruned: {pruned}")
 
     # Convert prefixes to a sortable form
     sortable_prefixes = []
-    for prefix in prefixes:
-        ip_prefix, asn = prefix.split(' ')
+    for ip_prefix, asn in entries:
         net = ipaddress.ip_network(ip_prefix)
         # Determine if the network is IPv4 or IPv6
         is_ipv6 = int(net.version == 6)

--- a/kartograf/sort.py
+++ b/kartograf/sort.py
@@ -5,6 +5,13 @@ from kartograf.prune import prune_entries
 from kartograf.timed import timed
 
 
+def _sort_key(entry):
+    # IPv4 before IPv6, then by network address, longer prefixes first for
+    # the same address, then by ASN
+    net = ipaddress.ip_network(entry[0])
+    return (int(net.version == 6), int(net.network_address), -net.prefixlen, entry[1])
+
+
 @timed
 def sort_result_by_pfx(context):
     if context.args.irr and context.args.routeviews:
@@ -24,32 +31,13 @@ def sort_result_by_pfx(context):
     entries, pruned = prune_entries(entries)
     print(f"Redundant entries pruned: {pruned}")
 
-    # Convert prefixes to a sortable form
-    sortable_prefixes = []
-    for ip_prefix, asn in entries:
-        net = ipaddress.ip_network(ip_prefix)
-        # Determine if the network is IPv4 or IPv6
-        is_ipv6 = int(net.version == 6)
-        # Create a tuple containing whether it's IPv6, the IP network as an
-        # integer, the prefix length (negated for descending order), and the
-        # ASN
-        sortable_prefixes.append((is_ipv6,
-                                  int(net.network_address),
-                                  -net.prefixlen,
-                                  asn))
-
-    sortable_prefixes.sort()
+    # The prefixes are canonical strings from our parsers, so they are
+    # written back as they are once sorted.
+    entries.sort(key=_sort_key)
 
     sorted_out_file = Path(context.out_dir) / "merged_file_sorted.txt"
     with open(sorted_out_file, "w") as file:
-        for is_ipv6, net_int, neg_prefixlen, asn in sortable_prefixes:
-            prefixlen = -neg_prefixlen
-            if is_ipv6:
-                net_address = ipaddress.IPv6Address(net_int)
-                net = ipaddress.IPv6Network((net_address, prefixlen))
-            else:
-                net_address = ipaddress.IPv4Address(net_int)
-                net = ipaddress.IPv4Network((net_address, prefixlen))
-            file.write(f'{str(net)} {asn}\n')
+        for prefix, asn in entries:
+            file.write(f"{prefix} {asn}\n")
 
     sorted_out_file.rename(Path(context.final_result_file))

--- a/tests/test_collectors_parse.py
+++ b/tests/test_collectors_parse.py
@@ -34,3 +34,20 @@ def test_parse(tmp_path):
     assert "2ab1:db8::/32 AS33521665" not in results
 
     assert results == ["1.0.0.0/24 AS13335", "1.0.4.0/24 AS38803", "1.0.16.0/24 AS2519"]
+
+
+def test_parse_prunes_same_asn_more_specifics(tmp_path, capsys):
+    context = build_test_context(tmp_path)
+    raw_file = Path(context.out_dir_collectors) / "pfx2asn.txt"
+    raw_file.write_text("1.0.0.0/23 AS1\n1.0.0.0/24 AS1\n1.0.1.0/24 AS2\n")
+
+    parse_routeviews_pfx2as(context)
+
+    result_file = Path(context.out_dir_collectors) / "pfx2asn_clean.txt"
+    with open(result_file, 'r') as f:
+        results = [l.strip() for l in f.readlines()]
+
+    assert results == ["1.0.0.0/23 AS1", "1.0.1.0/24 AS2"]
+    captured = capsys.readouterr()
+    assert "Entries after cleanup: 2" in captured.out
+    assert "Redundant entries pruned: 1" in captured.out

--- a/tests/test_irr_parse.py
+++ b/tests/test_irr_parse.py
@@ -45,5 +45,34 @@ def test_parse_validation_cases(tmp_path):
     # Last complete object has no trailing blank in the fixture
     assert "212.20.0.0/24 AS12345" in content
 
-    # Test expected set
-    assert content == ["193.254.30.0/24 AS12726", "212.166.64.0/19 AS12321", "212.80.191.0/24 AS12541", "212.16.0.0/24 AS12346", "212.17.0.0/24 AS12347", "2345:2ca::/32 AS12345", "212.20.0.0/24 AS12345"]
+    # Test expected set, the output is sorted by IP version and network
+    assert content == ["193.254.30.0/24 AS12726", "212.16.0.0/24 AS12346", "212.17.0.0/24 AS12347", "212.20.0.0/24 AS12345", "212.80.191.0/24 AS12541", "212.166.64.0/19 AS12321", "2345:2ca::/32 AS12345"]
+
+
+def test_parse_prunes_same_asn_more_specifics(tmp_path, capsys):
+    context = create_test_context(tmp_path, "111111113")
+    irr_file = Path(context.out_dir_irr) / "irr_ripe_nested.txt"
+    irr_file.write_text(
+        "route:          212.100.0.0/23\n"
+        "origin:         AS1\n"
+        "source:         RIPE\n"
+        "\n"
+        "route:          212.100.0.0/24\n"
+        "origin:         AS1\n"
+        "source:         RIPE\n"
+        "\n"
+        "route:          212.100.1.0/24\n"
+        "origin:         AS2\n"
+        "source:         RIPE\n"
+    )
+
+    parse_irr(context)
+
+    result_file = Path(context.out_dir_irr) / "irr_final.txt"
+    with open(str(result_file), 'r') as f:
+        content = [l.strip() for l in f.readlines()]
+
+    assert content == ["212.100.0.0/23 AS1", "212.100.1.0/24 AS2"]
+    captured = capsys.readouterr()
+    assert "Found valid, unique entries: 3" in captured.out
+    assert "Redundant entries pruned: 1" in captured.out

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from kartograf.merge import general_merge, pick_chunk_size
+from kartograf.prune import prune_entries
 
 from .util.generate_data import (
     build_file_lines,
@@ -171,3 +172,33 @@ def test_pick_chunk_size():
     assert pick_chunk_size(10, workers=4) == 5
     # min_chunk wins
     assert pick_chunk_size(0) == 5
+
+
+def test_pruned_extras_merge_to_the_same_canonical_result(tmp_path):
+    '''
+    Pruning a source before the merge must not change the final map. This
+    relies on the containment based coverage check: whatever a redundant
+    extra covered is also covered by its cover. The old check without the
+    prefix length comparison dropped the /8 below while keeping the /9.
+    '''
+    base = tmp_path / "base.txt"
+    base.write_text("12.0.0.0/22 AS100\n")
+    extras = [("12.0.0.0/8", "AS200"), ("12.128.0.0/9", "AS200"), ("12.0.0.0/23", "AS300")]
+
+    unpruned_extra = tmp_path / "extra.txt"
+    unpruned_extra.write_text("".join(f"{p} {a}\n" for p, a in extras))
+    pruned_extra = tmp_path / "extra_pruned.txt"
+    pruned_extra.write_text("".join(f"{p} {a}\n" for p, a in prune_entries(extras)[0]))
+
+    out_unpruned = tmp_path / "out_unpruned.txt"
+    out_pruned = tmp_path / "out_pruned.txt"
+    general_merge(base, unpruned_extra, None, out_unpruned)
+    general_merge(base, pruned_extra, None, out_pruned)
+
+    assert out_unpruned.read_text() == "12.0.0.0/22 AS100\n12.0.0.0/8 AS200\n12.128.0.0/9 AS200\n"
+    assert out_pruned.read_text() == "12.0.0.0/22 AS100\n12.0.0.0/8 AS200\n"
+
+    def canonical(path):
+        return prune_entries(tuple(l.split()) for l in path.read_text().splitlines())[0]
+
+    assert canonical(out_unpruned) == canonical(out_pruned) == [("12.0.0.0/8", "AS200"), ("12.0.0.0/22", "AS100")]

--- a/tests/test_prune.py
+++ b/tests/test_prune.py
@@ -1,0 +1,97 @@
+import ipaddress
+import random
+
+from kartograf.prune import prune_entries
+
+
+def test_nested_same_asn_is_dropped():
+    kept, removed = prune_entries([("10.0.0.0/23", "AS1"), ("10.0.0.0/24", "AS1")])
+    assert kept == [("10.0.0.0/23", "AS1")]
+    assert removed == 1
+
+
+def test_nested_different_asn_is_kept():
+    entries = [("10.0.0.0/23", "AS1"), ("10.0.0.0/24", "AS2")]
+    assert prune_entries(entries) == (entries, 0)
+
+
+def test_chain_collapses_to_least_specific():
+    entries = [("10.0.0.0/24", "AS1"), ("10.0.0.0/22", "AS1"), ("10.0.0.0/23", "AS1")]
+    assert prune_entries(entries) == ([("10.0.0.0/22", "AS1")], 2)
+
+
+def test_chain_with_different_asn_in_the_middle_is_kept():
+    # Dropping the /24 would hand its addresses to the /23 and AS2
+    entries = [("10.0.0.0/22", "AS1"), ("10.0.0.0/23", "AS2"), ("10.0.0.0/24", "AS1")]
+    assert prune_entries(entries) == (entries, 0)
+
+
+def test_sibling_networks_are_not_covers():
+    entries = [("10.0.0.0/24", "AS1"), ("10.0.1.0/24", "AS1"), ("10.0.2.0/23", "AS1")]
+    assert prune_entries(entries) == (entries, 0)
+
+
+def test_ipv4_and_ipv6_do_not_cover_each_other():
+    # ::a00:0/112 has the same integer address range start as 10.0.0.0/8
+    entries = [("10.0.0.0/8", "AS1"), ("::a00:0/112", "AS1"),
+               ("2001:db8::/32", "AS2"), ("2001:db8:1::/48", "AS2")]
+    kept, removed = prune_entries(entries)
+    assert kept == [("10.0.0.0/8", "AS1"), ("::a00:0/112", "AS1"), ("2001:db8::/32", "AS2")]
+    assert removed == 1
+
+
+def test_output_is_sorted_by_version_network_and_prefix_length():
+    entries = [("2001:db8::/32", "AS4"), ("192.0.2.0/24", "AS3"), ("10.0.0.0/24", "AS1"),
+               ("10.0.0.0/23", "AS2"), ("172.16.0.0/12", "AS2"), ("10.0.0.0/22", "AS1")]
+    kept, removed = prune_entries(entries)
+    assert kept == [("10.0.0.0/22", "AS1"), ("10.0.0.0/23", "AS2"), ("10.0.0.0/24", "AS1"),
+                    ("172.16.0.0/12", "AS2"), ("192.0.2.0/24", "AS3"), ("2001:db8::/32", "AS4")]
+    assert removed == 0
+
+
+def test_input_is_not_modified():
+    entries = [("10.0.0.0/24", "AS1"), ("10.0.0.0/23", "AS1")]
+    prune_entries(entries)
+    assert entries == [("10.0.0.0/24", "AS1"), ("10.0.0.0/23", "AS1")]
+
+
+def brute_force_kept(entries):
+    '''Keep an entry unless its most specific containing entry has the same ASN.'''
+    nets = [(ipaddress.ip_network(prefix), asn) for prefix, asn in entries]
+    kept = set()
+    for i, (net, asn) in enumerate(nets):
+        cover_len = -1
+        cover_asn = None
+        for j, (other, other_asn) in enumerate(nets):
+            if i == j or net.version != other.version:
+                continue
+            if other.prefixlen < net.prefixlen and net.subnet_of(other):
+                if other.prefixlen > cover_len:
+                    cover_len = other.prefixlen
+                    cover_asn = other_asn
+        if cover_len < 0 or cover_asn != asn:
+            kept.add(entries[i])
+    return kept
+
+
+def random_entries(rng, count):
+    entries = {}
+    while len(entries) < count:
+        if rng.random() < 0.7:
+            prefixlen = rng.randint(8, 24)
+            addr = ipaddress.IPv4Address(rng.getrandbits(32))
+        else:
+            prefixlen = rng.randint(16, 64)
+            # Small address space so that nesting is common
+            addr = ipaddress.IPv6Address(rng.getrandbits(48) << 80)
+        net = ipaddress.ip_network((addr, prefixlen), strict=False)
+        entries[str(net)] = f"AS{rng.randint(1, 3)}"
+    return list(entries.items())
+
+
+def test_randomized_against_brute_force():
+    for seed in range(25):
+        entries = random_entries(random.Random(seed), 150)
+        kept, removed = prune_entries(entries)
+        assert set(kept) == brute_force_kept(entries), f"seed {seed}"
+        assert len(kept) + removed == len(entries)

--- a/tests/test_rpki_parser.py
+++ b/tests/test_rpki_parser.py
@@ -19,8 +19,9 @@ def test_roa_validations(tmp_path, capsys):
     The ROA validation informs the user of invalids, incompletes, not-ROAs etc
     but not data is returned to that effect, so we test stdout's messages.
     We assert on the length of the output file, and assert on duplicates.
-    The fixtures file should output 7 entries, with 2 duplicates, 1 not-ROA, and
-    1 invalid entry.
+    The fixtures file should output 8 entries, with 5 duplicates, 1 not-ROA,
+    1 invalid entry and 2 entries pruned because they sit inside
+    2602:fd60::/44 which maps to the same ASN.
     '''
     epoch = "111111111"
     context = create_test_context(tmp_path, epoch)
@@ -37,8 +38,13 @@ def test_roa_validations(tmp_path, capsys):
 
     captured = capsys.readouterr()
 
-    assert len(final_lines) == 10, "Should have found 10 valid ROAs"
-    assert "Result entries written: 10" in captured.out
+    assert len(final_lines) == 8, "Should have written 8 entries"
+    assert "2602:fd60::/44 AS396503" in final_lines
+    assert "2602:fd60:e::/48 AS396503" not in final_lines
+    assert "2602:fd60:7::/48 AS396503" not in final_lines
+    assert "2602:fd60:11::/48 AS49134" in final_lines
+    assert "Result entries written: 8" in captured.out
+    assert "Redundant entries pruned: 2" in captured.out
     assert "Duplicates found: 5" in captured.out
     assert "Invalids found: 1" in captured.out
     assert "Incompletes: 0" in captured.out

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from kartograf.sort import sort_result_by_pfx
+from .context import create_test_context
+
+
+def test_sort_prunes_and_orders_result(tmp_path, capsys):
+    context = create_test_context(tmp_path, "111111113")
+    # The /24 only became redundant when the merge added the /23
+    unsorted = Path(context.out_dir_rpki) / "rpki_final.txt"
+    unsorted.write_text("10.0.1.0/24 AS2\n10.0.0.0/24 AS1\n10.0.0.0/23 AS1\n2001:db8::/32 AS3\n")
+
+    sort_result_by_pfx(context)
+
+    result = Path(context.final_result_file).read_text()
+    assert result == "10.0.0.0/23 AS1\n10.0.1.0/24 AS2\n2001:db8::/32 AS3\n"
+    assert "Redundant entries pruned: 1" in capsys.readouterr().out


### PR DESCRIPTION
Our results include redundant entries, e.g. longer prefixes with the same ASN as a shorter prefix that includes this prefix. This was primarily due to debugging purposes and we left the pruning of redundant information to the encoding step.

We never saw any issues coming from this in terms of result matches in collaborative runs until yesterday, this caused the confusing result here: https://github.com/bitcoin-core/asmap-data/issues/68#issuecomment-5531088208 There is a mismatch in the hash despite the coverage being the same (this is what the karto-server diff shows).

With these changes we discard redudant entries in each result files and then once more at the end. Doing it only at the end would be simpler but since the merge step it the most expensive part of our processing we can see some nice speed-ups from doing it for each source before merging because there is simply fewer data to merge.

While this makes a significant difference for the file coming out of the kartograf step the results are the same for the encoded result. I verified this for the last three runs. Thus I wouldn't call this a breaking change in the same way as our recent changes in `0.5.0`. But our reproduction CI job needs to be updated.

The logging of the pruned entries is a bit unnecesary but at least for the start I would like to have a closer eye on what is happening with this change and I hope we can remove this in a few weeks when we don't see any issues.