### PR TITLE
Bump nixpkgs to nixos-unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The recommended method of installation is with [Nix](https://nixos.org/download.
 
 ### Nix
 
-The Nix flake in this repo exposes a development shell, with the `rpki-client` binary, Python 3.11, and the Python packages required to run kartograf.
+The Nix flake in this repo exposes a development shell, with the `rpki-client` binary, Python 3.13, and the Python packages required to run kartograf.
 
 If you have Nix installed with flakes enabled, clone this repo, and run `nix develop`. You can now proceed to [Usage](#usage).
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769598131,
-        "narHash": "sha256-e7VO/kGLgRMbWtpBqdWl0uFg8Y2XWFMdz0uUJvlML8o=",
+        "lastModified": 1788316716,
+        "narHash": "sha256-bc7rSpXIdn9QWGNqfWcPZWOhEVF8NoeAZkWq0XWnf/k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa83fd837f3098e3e678e6cf017b2b36102c7211",
+        "rev": "3ed67ec0a4d3c7ab4ae1f04f8ee8df07bfa506a2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "An IP-to-AS mapping tool.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     # the rpki-client binary will be built from the flake at this URL.
     rpki-cli.url = "github:asmap/rpki-client-nix";
     rpki-cli.inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,6 +1,6 @@
 {pkgs, rpki-client }:
 let
-      pythonBuildDeps = pkgs.python311.withPackages (ps: [
+      pythonBuildDeps = pkgs.python313.withPackages (ps: [
         ps.beautifulsoup4
         ps.pandas
         ps.requests


### PR DESCRIPTION
The Nix version kartograf currently uses has a bug. In the cache directory it cannot find `etc/ssl/cert.pem`, so a full run still looks fine at first, but the map is incomplete. That is exactly what happened in my run in the last collaborative launch, bitcoin-core/asmap-data#68. Luckily I ran with `-d` and got these lines:

```
rpki-client: https://rrdp.arin.net/notification.xml (199.71.0.130): TLS connect: failed to open CA file 'etc/ssl/cert.pem': No such file or directory
rpki-client: https://rrdp.arin.net/notification.xml: load from network failed, fallback to rsync

rsync warning: some files vanished before they could be transferred (code 24) at main.c(1872) [generator=3.4.1]
rpki-client: rsync rsync://rpki.arin.net/repository failed
```

The bug in the current version is that the path is relative, so every HTTPS fetch fails and rpki-client falls back to rsync. It still exits 0, so without `-d` nothing looks wrong. For ARIN, rsync failed too and that whole repository was missing. The same TLS error showed up on Linux as well, so other Nix users may have hit this too.

The bug is known, but the fix is only on nixos-unstable right now (NixOS/nixpkgs#540702). The latest stable version (nixos-26.05) still has the broken LibreSSL. This PR bumps the flake there and pins `3ed67ec` (Sept 2). In the same step, `nix/package.nix` moves from python311 to python313, because 3.11 no longer builds on unstable.

A few other versions go up too. The big one is pandas 2.3.1 -> 3.0.4, which is what the pip CI already uses, and I checked it should not change anything else. I re-ran two reproductions, master vs this branch, and got the same hashes both times.