### PR TITLE
Add missing newlines to parser messages

### DIFF
--- a/kartograf/collectors/parse.py
+++ b/kartograf/collectors/parse.py
@@ -36,7 +36,7 @@ def parse_routeviews_pfx2as(context):
                 if not prefix or is_bogon_pfx(prefix) or is_bogon_asn(asn):
                     if context.debug_log:
                         with open(context.debug_log, 'a') as logs:
-                            logs.write(f"Routeviews: parser encountered an invalid IP network: {prefix}")
+                            logs.write(f"Routeviews: parser encountered an invalid IP network: {prefix}\n")
                     continue
 
                 entries.append((prefix, asn))
@@ -64,7 +64,7 @@ def parse_routeviews_pfx2as(context):
             if is_bogon_pfx(prefix) or is_bogon_asn(asn):
                 if context.debug_log:
                     with open(context.debug_log, 'a') as logs:
-                        logs.write(f"Routeviews: parser encountered an invalid IP network: {prefix}")
+                        logs.write(f"Routeviews: parser encountered an invalid IP network: {prefix}\n")
                 continue
 
             if context.max_encode and is_out_of_encoding_range(asn, context.max_encode):

--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -73,7 +73,7 @@ def parse_irr(context):
                     if not parsed_route:
                         if context.debug_log:
                             with open(context.debug_log, 'a') as logs:
-                                logs.write(f"Could not parse prefix from line: {route}")
+                                logs.write(f"Could not parse prefix from line: {route}\n")
                         continue
 
                     # AFRINIC and LACNIC appear to not use last modified anymore

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -69,7 +69,7 @@ def parse_rpki(context):
                 if not prefix:
                     if context.debug_log:
                         with open(context.debug_log, 'a') as logs:
-                            logs.write(f"Could not parse prefix from line: {vrp['prefix']}")
+                            logs.write(f"Could not parse prefix from line: {vrp['prefix']}\n")
                     continue
                 # Bogon prefixes and ASNs are excluded since they can not
                 # be used for routing.


### PR DESCRIPTION
While reading the debug.log from one of my runs I noticed the unparseable-prefix lines don't break. Right now that turns into one long line:
```
Could not parse prefix from line: 209.087.064.000/19Could not parse prefix from line: 209.101.000.000/16Could not parse prefix from line: 209.166.000.000/18IRR: parser encountered an invalid route: 209.188.64.0/20
```
After this PR each message is its own line like the others:
```
Could not parse prefix from line: 209.087.064.000/19
Could not parse prefix from line: 209.101.000.000/16
Could not parse prefix from line: 209.166.000.000/18
IRR: parser encountered an invalid route: 209.188.64.0/20
```
Same missing `\n` on the RPKI parse-fail write and on both Routeviews writes (those currently dump the whole Routeviews debug section as a single line at the end of the file).