### PR TITLE
Add log debug helper, fix bogon logging

### DIFF
--- a/kartograf/collectors/parse.py
+++ b/kartograf/collectors/parse.py
@@ -33,8 +33,14 @@ def parse_routeviews_pfx2as(context):
                 if context.max_encode and is_out_of_encoding_range(asn, context.max_encode):
                     continue
 
-                if not prefix or is_bogon_pfx(prefix) or is_bogon_asn(asn):
-                    context.debug(f"Routeviews: parser encountered an invalid IP network: {prefix}")
+                if not prefix:
+                    context.debug(f"Routeviews: could not parse prefix from line: {line.strip()}")
+                    continue
+                if is_bogon_pfx(prefix):
+                    context.debug(f"Routeviews: parser encountered a bogon prefix: {prefix}")
+                    continue
+                if is_bogon_asn(asn):
+                    context.debug(f"Routeviews: parser encountered a bogon ASN: {asn}")
                     continue
 
                 entries.append((prefix, asn))
@@ -59,8 +65,11 @@ def parse_routeviews_pfx2as(context):
 
             if not prefix:
                 continue
-            if is_bogon_pfx(prefix) or is_bogon_asn(asn):
-                context.debug(f"Routeviews: parser encountered an invalid IP network: {prefix}")
+            if is_bogon_pfx(prefix):
+                context.debug(f"Routeviews: parser encountered a bogon prefix: {prefix}")
+                continue
+            if is_bogon_asn(asn):
+                context.debug(f"Routeviews: parser encountered a bogon ASN: {asn}")
                 continue
 
             if context.max_encode and is_out_of_encoding_range(asn, context.max_encode):

--- a/kartograf/collectors/parse.py
+++ b/kartograf/collectors/parse.py
@@ -34,9 +34,7 @@ def parse_routeviews_pfx2as(context):
                     continue
 
                 if not prefix or is_bogon_pfx(prefix) or is_bogon_asn(asn):
-                    if context.debug_log:
-                        with open(context.debug_log, 'a') as logs:
-                            logs.write(f"Routeviews: parser encountered an invalid IP network: {prefix}")
+                    context.debug(f"Routeviews: parser encountered an invalid IP network: {prefix}")
                     continue
 
                 entries.append((prefix, asn))
@@ -62,9 +60,7 @@ def parse_routeviews_pfx2as(context):
             if not prefix:
                 continue
             if is_bogon_pfx(prefix) or is_bogon_asn(asn):
-                if context.debug_log:
-                    with open(context.debug_log, 'a') as logs:
-                        logs.write(f"Routeviews: parser encountered an invalid IP network: {prefix}")
+                context.debug(f"Routeviews: parser encountered an invalid IP network: {prefix}")
                 continue
 
             if context.max_encode and is_out_of_encoding_range(asn, context.max_encode):

--- a/kartograf/context.py
+++ b/kartograf/context.py
@@ -83,6 +83,15 @@ class Context:
             self.debug_log = ""
 
 
+    def debug(self, message):
+        '''
+        Append the message to the run's debug.log, one line per message.
+        No-op when debug logging is disabled.
+        '''
+        if self.debug_log:
+            with open(self.debug_log, 'a') as logs:
+                logs.write(f"{message}\n")
+
     def _set_epoch_dirs(self):
         '''
         If doing a reproduction run, we will prepend the directory name with a "r"

--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -82,8 +82,11 @@ def parse_irr(context):
 
                     # Bogon prefixes and ASNs are excluded since they can not
                     # be used for routing.
-                    if is_bogon_pfx(parsed_route) or is_bogon_asn(origin):
-                        context.debug(f"IRR: parser encountered an invalid route: {parsed_route}")
+                    if is_bogon_pfx(parsed_route):
+                        context.debug(f"IRR: parser encountered a bogon route: {parsed_route}")
+                        continue
+                    if is_bogon_asn(origin):
+                        context.debug(f"IRR: parser encountered a bogon ASN: {origin}")
                         continue
 
                     if context.max_encode and is_out_of_encoding_range(origin, context.max_encode):

--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -71,9 +71,7 @@ def parse_irr(context):
 
                     parsed_route = parse_pfx(route)
                     if not parsed_route:
-                        if context.debug_log:
-                            with open(context.debug_log, 'a') as logs:
-                                logs.write(f"Could not parse prefix from line: {route}")
+                        context.debug(f"Could not parse prefix from line: {route}")
                         continue
 
                     # AFRINIC and LACNIC appear to not use last modified anymore
@@ -85,9 +83,7 @@ def parse_irr(context):
                     # Bogon prefixes and ASNs are excluded since they can not
                     # be used for routing.
                     if is_bogon_pfx(parsed_route) or is_bogon_asn(origin):
-                        if context.debug_log:
-                            with open(context.debug_log, 'a') as logs:
-                                logs.write(f"IRR: parser encountered an invalid route: {parsed_route}\n")
+                        context.debug(f"IRR: parser encountered an invalid route: {parsed_route}")
                         continue
 
                     if context.max_encode and is_out_of_encoding_range(origin, context.max_encode):

--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -61,13 +61,11 @@ def fetch_rpki_db(context):
                                 capture_output=True,
                                 check=False)
 
-        if context.debug_log:
-            with open(context.debug_log, 'a') as logs:
-                logs.write("=== RPKI Download ===\n")
-                if result.stdout:
-                    logs.write(result.stdout.decode())
-                if result.stderr:
-                    logs.write(result.stderr.decode())
+        context.debug("\n\n=== RPKI Download ===")
+        if result.stdout:
+            context.debug(result.stdout.decode())
+        if result.stderr:
+            context.debug(result.stderr.decode())
 
         if result.returncode != 0:
             print(f"rpki-client exited with code {result.returncode} "
@@ -98,9 +96,7 @@ def validate_rpki_db(context):
 
     debug_file_lock = Lock()
 
-    if context.debug_log:
-        with open(context.debug_log, 'a') as logs:
-            logs.write("\n\n=== RPKI Validation ===\n")
+    context.debug("\n\n=== RPKI Validation ===")
 
     def process_files_batch(batch):
         result = subprocess.run(["rpki-client",
@@ -120,11 +116,10 @@ def validate_rpki_db(context):
             print(result.stderr.decode() if result.stderr else "(no stderr)")
             sys.exit(1)
 
-        if result.stderr and context.debug_log:
+        if result.stderr:
             stderr_output = result.stderr.decode()
             with debug_file_lock:
-                with open(context.debug_log, 'a') as logs:
-                    logs.write(stderr_output)
+                context.debug(stderr_output)
         return result.stdout
 
     total = len(files)

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -67,16 +67,12 @@ def parse_rpki(context):
                 asn = vrp['asid']
                 prefix = parse_pfx(vrp['prefix'])
                 if not prefix:
-                    if context.debug_log:
-                        with open(context.debug_log, 'a') as logs:
-                            logs.write(f"Could not parse prefix from line: {vrp['prefix']}")
+                    context.debug(f"Could not parse prefix from line: {vrp['prefix']}")
                     continue
                 # Bogon prefixes and ASNs are excluded since they can not
                 # be used for routing.
                 if is_bogon_pfx(prefix) or is_bogon_asn(asn):
-                    if context.debug_log:
-                        with open(context.debug_log, 'a') as logs:
-                            logs.write(f"RPKI: parser encountered an invalid IP network: {prefix}\n")
+                    context.debug(f"RPKI: parser encountered an invalid IP network: {prefix}")
                     continue
 
                 if context.max_encode and is_out_of_encoding_range(asn, context.max_encode):

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -71,8 +71,11 @@ def parse_rpki(context):
                     continue
                 # Bogon prefixes and ASNs are excluded since they can not
                 # be used for routing.
-                if is_bogon_pfx(prefix) or is_bogon_asn(asn):
-                    context.debug(f"RPKI: parser encountered an invalid IP network: {prefix}")
+                if is_bogon_pfx(prefix):
+                    context.debug(f"RPKI: parser encountered a bogon prefix: {prefix}")
+                    continue
+                if is_bogon_asn(asn):
+                    context.debug(f"RPKI: parser encountered a bogon ASN: {asn}")
                     continue
 
                 if context.max_encode and is_out_of_encoding_range(asn, context.max_encode):

--- a/tests/test_collectors_parse.py
+++ b/tests/test_collectors_parse.py
@@ -36,6 +36,29 @@ def test_parse(tmp_path):
     assert results == ["1.0.0.0/24 AS13335", "1.0.4.0/24 AS38803", "1.0.16.0/24 AS2519"]
 
 
+def test_bogons_logged_separately(tmp_path):
+    '''
+    Bogon prefixes and bogon ASNs are logged separately.
+    '''
+    context = build_test_context(tmp_path)
+    context.debug_log = str(tmp_path / "debug.log")
+
+    raw_file = Path(context.out_dir_collectors) / "pfx2asn.txt"
+    raw_file.write_text(
+        "1.0.0.0/24 AS13335\n"
+        "192.168.0.0/16 AS1234\n"
+        "1.0.4.0/24 AS64512\n"
+    )
+
+    parse_routeviews_pfx2as(context)
+
+    with open(context.debug_log, "r") as f:
+        log = f.read()
+
+    assert "Routeviews: parser encountered a bogon prefix: 192.168.0.0/16" in log
+    assert "Routeviews: parser encountered a bogon ASN: AS64512" in log
+
+
 def test_parse_prunes_same_asn_more_specifics(tmp_path, capsys):
     context = build_test_context(tmp_path)
     raw_file = Path(context.out_dir_collectors) / "pfx2asn.txt"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -26,6 +26,31 @@ def test_basic_map_context(parser, tmp_path):
     assert context.max_encode == 33521664
     assert Path(context.debug_log).name == ''
 
+
+def test_debug_disabled_writes_nothing(parser, tmp_path):
+    args = parser.parse_args(['map'])
+    os.chdir(tmp_path)  # Use temporary directory
+    context = Context(args)
+
+    assert context.debug_log == ''
+
+    context.debug("should not be written")
+
+    assert not list(tmp_path.rglob("debug.log"))
+
+
+def test_debug_appends_one_line_per_message(parser, tmp_path):
+    args = parser.parse_args(['map'])
+    os.chdir(tmp_path)  # Use temporary directory
+    context = Context(args)
+    context.debug_log = str(tmp_path / "debug.log")
+
+    context.debug("first")
+    context.debug("second")
+
+    assert (tmp_path / "debug.log").read_text() == "first\nsecond\n"
+
+
 def test_map_context_with_reproduce(parser, tmp_path):
     # Setup a mock reproduction directory
     repro_path = tmp_path / "repro"

--- a/tests/test_irr_parse.py
+++ b/tests/test_irr_parse.py
@@ -49,6 +49,37 @@ def test_parse_validation_cases(tmp_path):
     assert content == ["193.254.30.0/24 AS12726", "212.16.0.0/24 AS12346", "212.17.0.0/24 AS12347", "212.20.0.0/24 AS12345", "212.80.191.0/24 AS12541", "212.166.64.0/19 AS12321", "2345:2ca::/32 AS12345"]
 
 
+def test_bogons_logged_separately(tmp_path):
+    '''
+    Bogon prefixes and bogon ASNs are logged separately.
+    '''
+    context = create_test_context(tmp_path, "111111114")
+    context.debug_log = str(tmp_path / "debug.log")
+
+    irr_file = Path(context.out_dir_irr) / "irr_ripe_bogons.txt"
+    irr_file.write_text(
+        "route:          212.16.0.0/24\n"
+        "origin:         AS12345\n"
+        "source:         RIPE\n"
+        "\n"
+        "route:          192.168.0.0/16\n"
+        "origin:         AS12345\n"
+        "source:         RIPE\n"
+        "\n"
+        "route:          212.17.0.0/24\n"
+        "origin:         AS64512\n"
+        "source:         RIPE\n"
+    )
+
+    parse_irr(context)
+
+    with open(context.debug_log, "r") as f:
+        log = f.read()
+
+    assert "IRR: parser encountered a bogon route: 192.168.0.0/16" in log
+    assert "IRR: parser encountered a bogon ASN: AS64512" in log
+
+
 def test_parse_prunes_same_asn_more_specifics(tmp_path, capsys):
     context = create_test_context(tmp_path, "111111113")
     irr_file = Path(context.out_dir_irr) / "irr_ripe_nested.txt"

--- a/tests/test_rpki_parser.py
+++ b/tests/test_rpki_parser.py
@@ -149,6 +149,58 @@ def test_roa_asn_fallback(tmp_path):
     assert "103.0.1.0/24 AS11105" in entries, "ROA with lower ASN should be selected"
     assert not any("103.0.1.0/24 AS11106" in e for e in entries), "ROA with higher ASN should not be selected"
 
+def test_roa_bogons_logged_separately(tmp_path):
+    '''
+    Bogon prefixes and bogon ASNs are logged separately.
+    '''
+    epoch = "111111114"
+    context = create_test_context(tmp_path, epoch)
+    context.debug_log = str(tmp_path / "debug.log")
+
+    roas = [
+        {
+            "type": "roa",
+            "validation": "OK",
+            "aki": "some-aki",
+            "ski": "some-ski",
+            "vrps": [{"prefix": "192.0.1.0/24", "asid": "13335", "maxlen": "24"}],
+            "valid_until": "1234567890",
+            "valid_since": "1234567880"
+        },
+        {
+            # AS_TRANS, reserved
+            "type": "roa",
+            "validation": "OK",
+            "aki": "some-aki",
+            "ski": "some-ski",
+            "vrps": [{"prefix": "45.0.1.0/24", "asid": "23456", "maxlen": "24"}],
+            "valid_until": "1234567890",
+            "valid_since": "1234567880"
+        },
+        {
+            # TEST-NET-1, documentation range
+            "type": "roa",
+            "validation": "OK",
+            "aki": "some-aki",
+            "ski": "some-ski",
+            "vrps": [{"prefix": "192.0.2.0/24", "asid": "13335", "maxlen": "24"}],
+            "valid_until": "1234567890",
+            "valid_since": "1234567880"
+        },
+    ]
+
+    with open(os.path.join(context.out_dir_rpki, "rpki_raw.json"), "w") as f:
+        json.dump(roas, f)
+
+    parse_rpki(context)
+
+    with open(context.debug_log, "r") as f:
+        log = f.read()
+
+    assert "RPKI: parser encountered a bogon ASN: 23456" in log
+    assert "RPKI: parser encountered a bogon prefix: 192.0.2.0/24" in log
+
+
 def test_no_valid_output_exits(tmp_path, capsys):
     """
     When all ROAs in the input are filtered out (e.g. all incomplete


### PR DESCRIPTION
When parsing invalid prefixes and ASNs, and if debug is enabled, we write lines to `debug.log`, for example: 
```
RPKI: parser encountered an invalid IP network: 155.186.0.0/16
RPKI: parser encountered an invalid IP network: 63.75.240.0/20
```
irrespective of whether the error is the network or a bogon AS. 

While fixing this I decided to extract a generic logging function so we don't repeat the same ceremony everywhere.

d5f15e9164412e87d663e3872c829d5c2e70434a refactors logging calls into a `context.debug(self, msg)` function in the Context module. I thought about putting this in util or somewhere else but context seems like the best place for it since it's tied to `context.debug_log`. 

24fdd9a2b3d5c655e32b3aca54a82b7742b631c0 splits the bundled prefix and ASN logging into separate log messages.